### PR TITLE
chore: removed ParseReader Method the last array returning method

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -55,28 +55,6 @@ func (p *Parser) ParseLine(line string) (*LogEntry, error) {
 	return entry, nil
 }
 
-// ParseReader parses log entries from an io.Reader
-// Deprecated: Use NewIterator for memory-efficient processing of large files
-func (p *Parser) ParseReader(reader io.Reader) ([]*LogEntry, error) {
-	var entries []*LogEntry
-	scanner := bufio.NewScanner(reader)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		entry, err := p.ParseLine(line)
-		if err != nil {
-			return nil, err
-		}
-		entries = append(entries, entry)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return entries, nil
-}
-
 // NewIterator creates a new LogIterator for memory-efficient processing
 func (p *Parser) NewIterator(reader io.Reader) *LogIterator {
 	return &LogIterator{

--- a/parser_test.go
+++ b/parser_test.go
@@ -200,13 +200,18 @@ func TestParseReader(t *testing.T) {
 		"\x1b_bk;t=1745322209948\x07~~~ Running global pre-checkout hook"
 
 	reader := strings.NewReader(input)
-	entries, err := parser.ParseReader(reader)
-	if err != nil {
-		t.Fatalf("ParseReader() error = %v", err)
+
+	// Collect entries using streaming iterator
+	var entries []*LogEntry
+	for entry, err := range parser.All(reader) {
+		if err != nil {
+			t.Fatalf("Parser.All() error = %v", err)
+		}
+		entries = append(entries, entry)
 	}
 
 	if len(entries) != 4 {
-		t.Fatalf("ParseReader() got %d entries, want 4", len(entries))
+		t.Fatalf("Parser.All() got %d entries, want 4", len(entries))
 	}
 
 	// Check first entry

--- a/scanner.go
+++ b/scanner.go
@@ -1,6 +1,7 @@
 package buildkitelogs
 
 import (
+	"bytes"
 	"strconv"
 	"time"
 )
@@ -76,12 +77,7 @@ func hasOSCStart(data []byte) bool {
 	}
 
 	return data[0] == 0x1b && // ESC
-		data[1] == '_' &&
-		data[2] == 'b' &&
-		data[3] == 'k' &&
-		data[4] == ';' &&
-		data[5] == 't' &&
-		data[6] == '='
+		bytes.HasPrefix(data[1:], []byte("_bk;t="))
 }
 
 // findBEL finds the position of the BEL character (\x07) starting from offset


### PR DESCRIPTION
- Deleted the deprecated ParseReader method from Parser struct
- Method returned ([]*LogEntry, error) - the last array return in the codebase
- Already deprecated with comment directing users to streaming alternatives
