### PR TITLE
feat: updated query cli to add download and cache from bk api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 cmd/bklog/bklog
 # Added by goreleaser init:
 dist/
+/.envrc*

--- a/README.md
+++ b/README.md
@@ -239,6 +239,36 @@ Query time: 0.36 ms
 ./build/bklog query -file output.parquet -op info
 ```
 
+#### Buildkite API Integration
+
+The query command now supports direct API integration, automatically downloading and caching logs from Buildkite:
+
+**Query logs directly from Buildkite API:**
+```bash
+export BUILDKITE_API_TOKEN="bkua_your_token_here"
+./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op list-groups
+```
+
+**Query specific group from API logs:**
+```bash
+export BUILDKITE_API_TOKEN="bkua_your_token_here"
+./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op by-group -group "tests"
+```
+
+**Query last 10 entries from API logs:**
+```bash
+export BUILDKITE_API_TOKEN="bkua_your_token_here"
+./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op tail -tail 10
+```
+
+**Get file info for cached API logs:**
+```bash
+export BUILDKITE_API_TOKEN="bkua_your_token_here"
+./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op info
+```
+
+Logs are automatically downloaded and cached in `~/.bklog/` as `{org}-{pipeline}-{build}-{job}.parquet` files. Subsequent queries use the cached version unless the cache is manually cleared.
+
 #### Real Examples Using Test Data
 
 The repository includes test data files that you can use to try out the tail functionality:
@@ -308,7 +338,16 @@ Output:
 ./build/bklog query [options]
 ```
 
-- `-file <path>`: Path to Parquet log file (required)
+**Data Source Options (choose one):**
+- `-file <path>`: Path to Parquet log file (use this OR API parameters below)
+
+**Buildkite API Options:**
+- `-org <slug>`: Buildkite organization slug (for API access)
+- `-pipeline <slug>`: Buildkite pipeline slug (for API access)
+- `-build <number>`: Buildkite build number or UUID (for API access)
+- `-job <id>`: Buildkite job ID (for API access)
+
+**Query Options:**
 - `-op <operation>`: Query operation (`list-groups`, `by-group`, `info`, `tail`, `seek`) (default: `list-groups`)
 - `-group <pattern>`: Group name pattern to filter by (for `by-group` operation)
 - `-format <format>`: Output format (`text`, `json`) (default: `text`)
@@ -316,6 +355,8 @@ Output:
 - `-limit <number>`: Limit number of entries returned (0 = no limit, enables early termination)
 - `-tail <number>`: Number of lines to show from end (for `tail` operation, default: 10)
 - `-seek <row>`: Row number to seek to (0-based, for `seek` operation)
+
+**Note:** For API usage, set `BUILDKITE_API_TOKEN` environment variable. Logs are automatically downloaded and cached in `~/.bklog/`.
 
 ## Log Entry Types
 

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,97 @@
+package buildkitelogs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// GetCacheDir returns the cache directory path, creating it if it doesn't exist
+func GetCacheDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+
+	cacheDir := filepath.Join(homeDir, ".bklog")
+
+	// Create the cache directory if it doesn't exist
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	return cacheDir, nil
+}
+
+// GenerateCacheFilename creates a cache filename based on org, pipeline, build, and job
+func GenerateCacheFilename(org, pipeline, build, job string) string {
+	return fmt.Sprintf("%s-%s-%s-%s.parquet", org, pipeline, build, job)
+}
+
+// GetCacheFilePath returns the full path to a cached parquet file
+func GetCacheFilePath(org, pipeline, build, job string) (string, error) {
+	cacheDir, err := GetCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	filename := GenerateCacheFilename(org, pipeline, build, job)
+	return filepath.Join(cacheDir, filename), nil
+}
+
+// IsCacheFileExists checks if a cached parquet file exists
+func IsCacheFileExists(org, pipeline, build, job string) (bool, string, error) {
+	cacheFilePath, err := GetCacheFilePath(org, pipeline, build, job)
+	if err != nil {
+		return false, "", err
+	}
+
+	if _, err := os.Stat(cacheFilePath); os.IsNotExist(err) {
+		return false, cacheFilePath, nil
+	} else if err != nil {
+		return false, cacheFilePath, fmt.Errorf("failed to check cache file: %w", err)
+	}
+
+	return true, cacheFilePath, nil
+}
+
+// DownloadAndCache downloads logs from the Buildkite API and caches them as a parquet file
+func DownloadAndCache(apiToken, org, pipeline, build, job, version string) (string, error) {
+	// Check if cache file already exists
+	exists, cacheFilePath, err := IsCacheFileExists(org, pipeline, build, job)
+	if err != nil {
+		return "", err
+	}
+
+	if exists {
+		return cacheFilePath, nil
+	}
+
+	// Download logs from API
+	client := NewBuildkiteAPIClient(apiToken, version)
+	logReader, err := client.GetJobLog(org, pipeline, build, job)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch logs from API: %w", err)
+	}
+	defer logReader.Close()
+
+	// Parse and export to parquet
+	parser := NewParser()
+
+	// Create filter function (no filtering for cache)
+	countingSeq := func(yield func(*LogEntry, error) bool) {
+		for entry, err := range parser.All(logReader) {
+			if !yield(entry, err) {
+				return
+			}
+		}
+	}
+
+	// Export to cache file
+	err = ExportSeq2ToParquetWithFilter(countingSeq, cacheFilePath, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to export to cache: %w", err)
+	}
+
+	return cacheFilePath, nil
+}

--- a/cmd/bklog/main.go
+++ b/cmd/bklog/main.go
@@ -68,7 +68,7 @@ func printUsage() {
 	fmt.Printf("Usage: %s <subcommand> [options]\n\n", os.Args[0])
 	fmt.Println("Subcommands:")
 	fmt.Println("  parse     Parse Buildkite log files and export to various formats")
-	fmt.Println("  query     Query Parquet log files")
+	fmt.Println("  query     Query Parquet log files (supports local files and Buildkite API)")
 	fmt.Println("  version   Show version information")
 	fmt.Println("  help      Show this help message")
 	fmt.Println("")
@@ -150,7 +150,7 @@ func handleQueryCommand() {
 	var config QueryConfig
 
 	queryFlags := flag.NewFlagSet("query", flag.ExitOnError)
-	queryFlags.StringVar(&config.ParquetFile, "file", "", "Path to Parquet log file (required)")
+	queryFlags.StringVar(&config.ParquetFile, "file", "", "Path to Parquet log file (use this OR API parameters)")
 	queryFlags.StringVar(&config.Operation, "op", "list-groups", "Query operation: list-groups, by-group, info, tail, seek")
 	queryFlags.StringVar(&config.GroupName, "group", "", "Group name to filter by (for by-group operation)")
 	queryFlags.StringVar(&config.Format, "format", "text", "Output format: text, json")
@@ -158,10 +158,20 @@ func handleQueryCommand() {
 	queryFlags.IntVar(&config.LimitEntries, "limit", 0, "Limit number of entries returned (0 = no limit, enables early termination)")
 	queryFlags.IntVar(&config.TailLines, "tail", 10, "Number of lines to show from end (for tail operation)")
 	queryFlags.Int64Var(&config.SeekToRow, "seek", 0, "Row number to seek to (0-based, for seek operation)")
+	// Buildkite API parameters
+	queryFlags.StringVar(&config.Organization, "org", "", "Buildkite organization slug (for API)")
+	queryFlags.StringVar(&config.Pipeline, "pipeline", "", "Buildkite pipeline slug (for API)")
+	queryFlags.StringVar(&config.Build, "build", "", "Buildkite build number or UUID (for API)")
+	queryFlags.StringVar(&config.Job, "job", "", "Buildkite job ID (for API)")
 
 	queryFlags.Usage = func() {
-		fmt.Printf("Usage: %s query -file <parquet-file> [options]\n\n", os.Args[0])
-		fmt.Println("Query Parquet log files.")
+		fmt.Printf("Usage: %s query [options]\n\n", os.Args[0])
+		fmt.Println("Query Parquet log files from local files or Buildkite API.")
+		fmt.Println("\nYou must provide either:")
+		fmt.Println("  -file <path>     Local parquet file")
+		fmt.Println("  OR API params:   -org -pipeline -build -job")
+		fmt.Println("\nFor API usage, set BUILDKITE_API_TOKEN environment variable.")
+		fmt.Println("API logs are automatically downloaded and cached in ~/.bklog/")
 		fmt.Println("\nOptions:")
 		queryFlags.PrintDefaults()
 		fmt.Println("\nOperations:")
@@ -171,21 +181,45 @@ func handleQueryCommand() {
 		fmt.Println("  tail         Show last N entries from the file")
 		fmt.Println("  seek         Start reading from a specific row number")
 		fmt.Println("\nExamples:")
+		fmt.Printf("  # Local file:\n")
 		fmt.Printf("  %s query -file logs.parquet -op list-groups\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op by-group -group \"Running tests\"\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op info\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op tail -tail 20\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op seek -seek 1000 -limit 50\n", os.Args[0])
-		fmt.Printf("  %s query -file logs.parquet -op list-groups -format json\n", os.Args[0])
+		fmt.Printf("\n  # API:\n")
+		fmt.Printf("  %s query -org myorg -pipeline mypipe -build 123 -job abc-def -op list-groups\n", os.Args[0])
+		fmt.Printf("  %s query -org myorg -pipeline mypipe -build 123 -job abc-def -op by-group -group \"Running tests\"\n", os.Args[0])
+		fmt.Printf("  %s query -org myorg -pipeline mypipe -build 123 -job abc-def -op info\n", os.Args[0])
 	}
 
 	if err := queryFlags.Parse(os.Args[2:]); err != nil {
 		os.Exit(1)
 	}
 
-	if config.ParquetFile == "" {
+	// Validate that either file or API parameters are provided
+	hasFile := config.ParquetFile != ""
+	hasAPIParams := config.Organization != "" || config.Pipeline != "" || config.Build != "" || config.Job != ""
+
+	if !hasFile && !hasAPIParams {
+		fmt.Fprintf(os.Stderr, "Error: Must provide either -file or API parameters (-org, -pipeline, -build, -job)\n\n")
 		queryFlags.Usage()
 		os.Exit(1)
+	}
+
+	if hasFile && hasAPIParams {
+		fmt.Fprintf(os.Stderr, "Error: Cannot use both -file and API parameters simultaneously\n\n")
+		queryFlags.Usage()
+		os.Exit(1)
+	}
+
+	// If using API, validate all required parameters are present
+	if hasAPIParams {
+		if err := buildkitelogs.ValidateAPIParams(config.Organization, config.Pipeline, config.Build, config.Job); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n\n", err)
+			queryFlags.Usage()
+			os.Exit(1)
+		}
 	}
 
 	if err := runQuery(&config); err != nil {


### PR DESCRIPTION
You can now run the following.

    ./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op list-groups

This will download and cache the log data in ~/.bklogs using a slug generated from the params.
