### PR TITLE
feat: add raw output option for query sub commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ lint:
 	@echo "Running golangci-lint..."
 	golangci-lint run
 
+# Run linting with auto-fix
+.PHONY: lint-fix
+lint-fix:
+	@echo "Running golangci-lint with auto-fix..."
+	golangci-lint run --fix ./...
+
 # Build the binary
 .PHONY: build
 build:
@@ -105,6 +111,7 @@ help:
 	@echo "  clean      - Clean build artifacts"
 	@echo "  test       - Run tests"
 	@echo "  lint       - Run golangci-lint"
+	@echo "  lint-fix   - Run golangci-lint with auto-fix"
 	@echo "  build      - Build the binary with version $(VERSION)"
 	@echo "  dev        - Quick development build"
 	@echo "  deps       - Install and tidy dependencies"

--- a/README.md
+++ b/README.md
@@ -506,7 +506,6 @@ Output:
 
 ## Log Entry Types
 
-The parser can classify log entries into different types:
 
 ### Commands
 Lines that represent shell commands being executed:

--- a/cmd/bklog/main.go
+++ b/cmd/bklog/main.go
@@ -155,6 +155,7 @@ func handleQueryCommand() {
 	queryFlags.IntVar(&config.LimitEntries, "limit", 0, "Limit number of entries returned (0 = no limit, enables early termination)")
 	queryFlags.IntVar(&config.TailLines, "tail", 10, "Number of lines to show from end (for tail operation)")
 	queryFlags.Int64Var(&config.SeekToRow, "seek", 0, "Row number to seek to (0-based, for seek operation)")
+	queryFlags.BoolVar(&config.RawOutput, "raw", false, "Output raw log content without timestamps, groups, or other prefixes")
 	// Search operation parameters
 	queryFlags.StringVar(&config.SearchPattern, "pattern", "", "Regex pattern to search for (for search operation)")
 	queryFlags.IntVar(&config.AfterContext, "A", 0, "Show NUM lines after each match")
@@ -197,6 +198,7 @@ func handleQueryCommand() {
 		fmt.Printf("  %s query -file logs.parquet -op tail -tail 20\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op seek -seek 1000 -limit 50\n", os.Args[0])
 		fmt.Printf("  %s query -file logs.parquet -op dump -limit 100\n", os.Args[0])
+		fmt.Printf("  %s query -file logs.parquet -op dump -raw\n", os.Args[0])
 		fmt.Printf("\n  # API:\n")
 		fmt.Printf("  %s query -org myorg -pipeline mypipe -build 123 -job abc-def -op list-groups\n", os.Args[0])
 		fmt.Printf("  %s query -org myorg -pipeline mypipe -build 123 -job abc-def -op by-group -group \"Running tests\"\n", os.Args[0])

--- a/cmd/bklog/query_cli_test.go
+++ b/cmd/bklog/query_cli_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	buildkitelogs "github.com/wolfeidau/buildkite-logs-parquet"
+)
+
+func TestFormatLogEntries_RawOutput(t *testing.T) {
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	entries := []buildkitelogs.ParquetLogEntry{
+		{
+			Timestamp: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixMilli(),
+			Content:   "Test content 1",
+			Group:     "test-group",
+			Flags:     buildkitelogs.LogFlags(1 << 1), // IsCommand (1 << IsCommand)
+		},
+		{
+			Timestamp: time.Date(2025, 1, 1, 12, 1, 0, 0, time.UTC).UnixMilli(),
+			Content:   "Test content 2",
+			Group:     "",
+			Flags:     buildkitelogs.LogFlags(1 << 2), // IsGroup (1 << IsGroup)
+		},
+	}
+
+	config := &QueryConfig{RawOutput: true}
+
+	formatLogEntries(entries, config)
+
+	// Close writer and capture output
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy output: %v", err)
+	}
+	output := buf.String()
+
+	expected := "Test content 1\nTest content 2\n"
+	if output != expected {
+		t.Errorf("Raw output mismatch.\nGot: %q\nWant: %q", output, expected)
+	}
+}
+
+func TestFormatLogEntries_FormattedOutput(t *testing.T) {
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	entries := []buildkitelogs.ParquetLogEntry{
+		{
+			Timestamp: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC).UnixMilli(),
+			Content:   "Test content 1",
+			Group:     "test-group",
+			Flags:     buildkitelogs.LogFlags(1 << 1), // IsCommand (1 << IsCommand)
+		},
+		{
+			Timestamp: time.Date(2025, 1, 1, 12, 1, 0, 0, time.UTC).UnixMilli(),
+			Content:   "Group Title",
+			Group:     "Group Title",                  // Same as content
+			Flags:     buildkitelogs.LogFlags(1 << 2), // IsGroup (1 << IsGroup)
+		},
+	}
+
+	config := &QueryConfig{RawOutput: false}
+
+	formatLogEntries(entries, config)
+
+	// Close writer and capture output
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		t.Fatalf("Failed to copy output: %v", err)
+	}
+	output := buf.String()
+
+	// Should show timestamp, group, and CMD marker for first entry
+	// Should show timestamp and GRP marker for second entry (no duplicate group name)
+	if !strings.Contains(output, "[test-group] [CMD] Test content 1") {
+		t.Errorf("First entry not formatted correctly. Got: %s", output)
+	}
+	if !strings.Contains(output, "[GRP] Group Title") {
+		t.Errorf("Second entry not formatted correctly. Got: %s", output)
+	}
+	// Should not show duplicate group name
+	if strings.Contains(output, "[Group Title] [GRP] Group Title") {
+		t.Errorf("Group name should not be duplicated. Got: %s", output)
+	}
+	// Should contain expected content
+	if !strings.Contains(output, "Test content 1") {
+		t.Errorf("Missing first entry content. Got: %s", output)
+	}
+	if !strings.Contains(output, "Group Title") {
+		t.Errorf("Missing second entry content. Got: %s", output)
+	}
+}


### PR DESCRIPTION
Added -raw flag to the bklog query CLI that outputs raw log content without timestamps, groups, or formatting prefixes while preserving statistics output to stderr. Refactored output formatting into consistent, testable helper functions across all query operations (dump, tail, seek, by-group, search) and added unit tests with linting fixes and a new make lint-fix target.
