### PR TITLE
feat: added option to strip ansi codes from log content

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -1,0 +1,88 @@
+package buildkitelogs
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiRegex matches ANSI escape sequences including:
+// - Color codes: \x1b[0m, \x1b[31m, etc.
+// - Complex sequences: \x1b[0;31;40m
+// - OSC sequences: \x1b]0;title\x07
+// - Other control sequences: \x1b[2J, \x1b[H, etc.
+// - Incomplete sequences: \x1b[, \x1b[31, etc.
+var ansiRegex = regexp.MustCompile(`\x1b(?:\[[0-9;:? ]*[a-zA-Z]?|\](?:[^\x07\x1b]*(?:\x07|\x1b\\))?|[PX^_](?:[^\x1b]*\x1b\\)?|.?)`)
+
+// StripANSIRegex removes ANSI escape sequences from a string using regex
+func StripANSIRegex(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// StripANSI removes ANSI escape sequences using strings.Builder for efficiency
+func StripANSI(s string) string {
+	if !strings.Contains(s, "\x1b") {
+		return s // Fast path: no escape sequences
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(s)) // Pre-allocate capacity
+
+	b := []byte(s)
+	i := 0
+
+	for i < len(b) {
+		if b[i] == '\x1b' {
+			// Found ESC character, determine sequence type
+			i++ // Skip ESC
+
+			if i >= len(b) {
+				// Lone ESC at end of string, consume it
+				break
+			}
+
+			switch b[i] {
+			case '[':
+				// CSI sequence: ESC[...letter
+				i++ // Skip [
+				for i < len(b) && ((b[i] >= '0' && b[i] <= '9') || b[i] == ';' || b[i] == ':' || b[i] == '?' || b[i] == ' ') {
+					i++
+				}
+				if i < len(b) && ((b[i] >= 'A' && b[i] <= 'Z') || (b[i] >= 'a' && b[i] <= 'z')) {
+					i++ // Skip terminating letter
+				}
+				// If we hit end of string or invalid char, sequence is incomplete but consumed
+			case ']':
+				// OSC sequence: ESC]...BEL or ESC]...ESC\
+				i++ // Skip ]
+				for i < len(b) {
+					if b[i] == '\x07' { // BEL
+						i++
+						break
+					} else if b[i] == '\x1b' && i+1 < len(b) && b[i+1] == '\\' {
+						i += 2 // Skip ESC\
+						break
+					}
+					i++
+				}
+			case 'P', 'X', '^', '_':
+				// DCS, SOS, PM, APC sequences: ESC{char}...ESC\
+				i++ // Skip command char
+				for i < len(b) {
+					if b[i] == '\x1b' && i+1 < len(b) && b[i+1] == '\\' {
+						i += 2 // Skip ESC\
+						break
+					}
+					i++
+				}
+			default:
+				// Simple escape sequence (Fe commands) or lone ESC, just skip the character
+				i++
+			}
+		} else {
+			builder.WriteByte(b[i])
+			i++
+		}
+	}
+
+	return builder.String()
+}

--- a/ansi_bench_test.go
+++ b/ansi_bench_test.go
@@ -1,0 +1,202 @@
+package buildkitelogs
+
+import (
+	"strings"
+	"testing"
+)
+
+var (
+	// Benchmark inputs of different types and sizes
+	benchInputs = map[string]string{
+		"no_ansi":       strings.Repeat("hello world this is a log line without any ansi codes\n", 100),
+		"simple_ansi":   strings.Repeat("\x1b[31mred text\x1b[0m normal text\n", 100),
+		"complex_ansi":  strings.Repeat("\x1b[1;31;40mbold red on black\x1b[0m \x1b[32;1mgreen bold\x1b[0m \x1b[90mdim\x1b[0m\n", 100),
+		"buildkite_log": strings.Repeat("\x1b[90m2023-01-01 12:00:00.123\x1b[0m \x1b[32m[INFO]\x1b[0m \x1b[1mStarting build step\x1b[0m\n", 100),
+		"error_log":     strings.Repeat("\x1b[31;1mError:\x1b[0m \x1b[31mtest failed\x1b[0m\nDetails: \x1b[33mcheck logs\x1b[0m\n", 100),
+		"mixed_content": strings.Repeat("normal text \x1b[31mred\x1b[0m more normal \x1b[32mgreen\x1b[0m end\n", 100),
+		"heavy_ansi":    strings.Repeat("\x1b[31m\x1b[32m\x1b[33m\x1b[34m\x1b[35m\x1b[36m\x1b[37m\x1b[0mtext\x1b[2J\x1b[H\x1b]0;title\x07\n", 100),
+		"single_line":   "hello world",
+		"single_ansi":   "\x1b[31mred\x1b[0m",
+		"large_line":    strings.Repeat("x", 10000) + "\x1b[31mred\x1b[0m" + strings.Repeat("y", 10000),
+	}
+)
+
+// Benchmark StripANSI (custom parser) with various input types
+func BenchmarkStripANSI(b *testing.B) {
+	for name, input := range benchInputs {
+		b.Run(name, func(b *testing.B) {
+			b.SetBytes(int64(len(input)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = StripANSI(input)
+			}
+		})
+	}
+}
+
+// Benchmark StripANSIRegex with various input types
+func BenchmarkStripANSIRegex(b *testing.B) {
+	for name, input := range benchInputs {
+		b.Run(name, func(b *testing.B) {
+			b.SetBytes(int64(len(input)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = StripANSIRegex(input)
+			}
+		})
+	}
+}
+
+// Benchmark memory allocations comparison
+func BenchmarkStripANSIAllocs(b *testing.B) {
+	testInput := benchInputs["complex_ansi"]
+
+	b.Run("Custom", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(testInput)))
+		for i := 0; i < b.N; i++ {
+			_ = StripANSI(testInput)
+		}
+	})
+
+	b.Run("Regex", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(testInput)))
+		for i := 0; i < b.N; i++ {
+			_ = StripANSIRegex(testInput)
+		}
+	})
+}
+
+// Direct performance comparison
+func BenchmarkStripANSIComparison(b *testing.B) {
+	testInput := benchInputs["buildkite_log"]
+
+	b.Run("Custom", func(b *testing.B) {
+		b.SetBytes(int64(len(testInput)))
+		for i := 0; i < b.N; i++ {
+			_ = StripANSI(testInput)
+		}
+	})
+
+	b.Run("Regex", func(b *testing.B) {
+		b.SetBytes(int64(len(testInput)))
+		for i := 0; i < b.N; i++ {
+			_ = StripANSIRegex(testInput)
+		}
+	})
+}
+
+// Benchmark with different ANSI code densities
+func BenchmarkStripANSIDensity(b *testing.B) {
+	// Generate inputs with different ANSI code densities
+	densities := map[string]string{
+		"0_percent":   strings.Repeat("normal text line\n", 1000),
+		"10_percent":  generateDensityInput(1000, 0.1),
+		"25_percent":  generateDensityInput(1000, 0.25),
+		"50_percent":  generateDensityInput(1000, 0.5),
+		"75_percent":  generateDensityInput(1000, 0.75),
+		"100_percent": strings.Repeat("\x1b[31m\x1b[0m", 1000),
+	}
+
+	for density, input := range densities {
+		b.Run(density, func(b *testing.B) {
+			b.SetBytes(int64(len(input)))
+			for i := 0; i < b.N; i++ {
+				_ = StripANSI(input)
+			}
+		})
+	}
+}
+
+// Helper function to generate input with specified ANSI density
+func generateDensityInput(lines int, ansiDensity float64) string {
+	var builder strings.Builder
+	for i := 0; i < lines; i++ {
+		if float64(i%100)/100.0 < ansiDensity {
+			builder.WriteString("\x1b[31mline with ansi\x1b[0m\n")
+		} else {
+			builder.WriteString("normal line\n")
+		}
+	}
+	return builder.String()
+}
+
+// Benchmark realistic log processing scenario
+func BenchmarkLogProcessingScenario(b *testing.B) {
+	// Simulate processing 1000 log lines with typical buildkite formatting
+	logLines := make([]string, 1000)
+	for i := 0; i < 1000; i++ {
+		switch i % 4 {
+		case 0:
+			logLines[i] = "\x1b[90m2023-01-01 12:00:00.123\x1b[0m \x1b[32m[INFO]\x1b[0m Normal log line"
+		case 1:
+			logLines[i] = "\x1b[90m2023-01-01 12:00:01.456\x1b[0m \x1b[33m[WARN]\x1b[0m Warning message"
+		case 2:
+			logLines[i] = "\x1b[90m2023-01-01 12:00:02.789\x1b[0m \x1b[31m[ERROR]\x1b[0m Error occurred"
+		case 3:
+			logLines[i] = "Plain log line without ANSI codes"
+		}
+	}
+
+	totalBytes := 0
+	for _, line := range logLines {
+		totalBytes += len(line)
+	}
+	b.SetBytes(int64(totalBytes))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, line := range logLines {
+			_ = StripANSI(line)
+		}
+	}
+}
+
+// Benchmark the fast path optimization (no ANSI codes)
+func BenchmarkFastPath(b *testing.B) {
+	noAnsiInput := strings.Repeat("regular log line without any escape codes\n", 1000)
+
+	b.SetBytes(int64(len(noAnsiInput)))
+	for i := 0; i < b.N; i++ {
+		_ = StripANSI(noAnsiInput)
+	}
+}
+
+// Benchmark CleanContent and CleanGroup methods
+func BenchmarkParquetLogEntryClean(b *testing.B) {
+	entry := ParquetLogEntry{
+		Content: "\x1b[90m2023-01-01 12:00:00\x1b[0m \x1b[32m[INFO]\x1b[0m Starting build step  ",
+		Group:   "  \x1b[1mTest Group\x1b[0m  ",
+	}
+
+	b.Run("CleanContent", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = entry.CleanContent(true)
+		}
+	})
+
+	b.Run("CleanGroup", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = entry.CleanGroup(true)
+		}
+	})
+
+	b.Run("Both", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = entry.CleanContent(true)
+			_ = entry.CleanGroup(true)
+		}
+	})
+}
+
+// Benchmark worst-case scenario with many incomplete sequences
+func BenchmarkWorstCase(b *testing.B) {
+	// Create input with many incomplete ANSI sequences
+	worstCase := strings.Repeat("\x1b[\x1b[\x1b[text", 1000)
+
+	b.SetBytes(int64(len(worstCase)))
+	for i := 0; i < b.N; i++ {
+		_ = StripANSI(worstCase)
+	}
+}

--- a/ansi_stripping_performance.md
+++ b/ansi_stripping_performance.md
@@ -1,0 +1,57 @@
+# ANSI Stripping Performance Comparison
+
+## Why not use regex?
+
+While regex is simpler to implement, it has significant performance and memory overhead for ANSI stripping in high-throughput scenarios like log processing.
+
+## Benchmark Results
+
+### Direct Performance Comparison (Typical Buildkite Log)
+```
+BenchmarkStripANSIComparison/Custom-10    526,899    6,619 ns/op    1,163 MB/s    
+BenchmarkStripANSIComparison/Regex-10      26,035  139,110 ns/op       55 MB/s    
+```
+
+**Performance gain: ~21x faster** (1,163 MB/s vs 55 MB/s)
+
+### Memory Allocation Comparison
+```
+BenchmarkStripANSIAllocs/Custom-10    656,391    5,302 ns/op    6,784 B/op     1 allocs/op
+BenchmarkStripANSIAllocs/Regex-10      26,565  135,769 ns/op   14,723 B/op    12 allocs/op
+```
+
+**Memory efficiency:**
+- **12x fewer allocations** (1 vs 12 allocs/op)
+- **2.2x less memory** (6,784 vs 14,723 bytes/op)
+
+### Real-world Impact
+
+For processing 1 million log lines:
+- **Custom parser**: ~6.6 seconds
+- **Regex**: ~139 seconds (2.3 minutes)
+
+The custom parser also has a fast-path optimization for strings without ANSI codes:
+- **No ANSI content**: 91,530 MB/s (zero allocations)
+- **With ANSI content**: 1,100-1,400 MB/s (single allocation)
+
+## Implementation Trade-offs
+
+| Aspect | Regex | Custom Parser |
+|--------|-------|---------------|
+| Code complexity | Low | Medium |
+| Performance | Poor | Excellent |
+| Memory usage | High | Low |
+| Maintainability | High | Medium |
+| Correctness | Good | Excellent |
+
+## Conclusion
+
+The custom parser is chosen because:
+
+1. **20x performance improvement** is critical for log processing
+2. **Significantly lower memory pressure** in high-throughput scenarios  
+3. **Fast-path optimization** for strings without ANSI codes
+4. **Single allocation** vs multiple regex allocations
+5. **More precise** handling of edge cases (incomplete sequences, etc.)
+
+The regex implementation is maintained for comparison and verification purposes.

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -1,0 +1,262 @@
+package buildkitelogs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no ansi codes",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple color reset",
+			input:    "\x1b[0mhello",
+			expected: "hello",
+		},
+		{
+			name:     "color codes",
+			input:    "\x1b[31mred text\x1b[0m normal",
+			expected: "red text normal",
+		},
+		{
+			name:     "complex color codes",
+			input:    "\x1b[1;31;40mbold red on black\x1b[0m",
+			expected: "bold red on black",
+		},
+		{
+			name:     "multiple sequences",
+			input:    "\x1b[31mred\x1b[32m green\x1b[0m normal",
+			expected: "red green normal",
+		},
+		{
+			name:     "cursor movement",
+			input:    "\x1b[2J\x1b[Hclear screen",
+			expected: "clear screen",
+		},
+		{
+			name:     "buildkite log line",
+			input:    "\x1b[90m2023-01-01 12:00:00\x1b[0m \x1b[32m[INFO]\x1b[0m Starting build",
+			expected: "2023-01-01 12:00:00 [INFO] Starting build",
+		},
+		{
+			name:     "osc sequence with bell",
+			input:    "\x1b]0;Window Title\x07hello",
+			expected: "hello",
+		},
+		{
+			name:     "osc sequence with escape",
+			input:    "\x1b]0;Window Title\x1b\\hello",
+			expected: "hello",
+		},
+		{
+			name:     "dcs sequence",
+			input:    "\x1bP+q544e\x1b\\hello",
+			expected: "hello",
+		},
+		{
+			name:     "real buildkite error log",
+			input:    "\x1b[31;1mError:\x1b[0m \x1b[31mtest failed\x1b[0m\nDetails: \x1b[33mcheck logs\x1b[0m",
+			expected: "Error: test failed\nDetails: check logs",
+		},
+		{
+			name:     "mixed content",
+			input:    "before \x1b[31mred\x1b[0m middle \x1b[32mgreen\x1b[0m after",
+			expected: "before red middle green after",
+		},
+		{
+			name:     "escape at end",
+			input:    "hello world\x1b[0m",
+			expected: "hello world",
+		},
+		{
+			name:     "malformed escape incomplete",
+			input:    "hello \x1b[31",
+			expected: "hello ",
+		},
+		{
+			name:     "just escape",
+			input:    "\x1b",
+			expected: "",
+		},
+		{
+			name:     "unicode with ansi",
+			input:    "\x1b[31m🔥 Error: \x1b[0mUnicode test ✅",
+			expected: "🔥 Error: Unicode test ✅",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripANSI(tt.input)
+			if result != tt.expected {
+				t.Errorf("StripANSI() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripANSILargeInput(t *testing.T) {
+	// Test with a large input to ensure memory efficiency
+	var builder strings.Builder
+	for i := 0; i < 1000; i++ {
+		builder.WriteString("\x1b[31mred line ")
+		builder.WriteString(strings.Repeat("x", 100))
+		builder.WriteString("\x1b[0m\n")
+	}
+
+	largeInput := builder.String()
+	result := StripANSI(largeInput)
+
+	// Verify ANSI codes were actually removed
+	if strings.Contains(result, "\x1b[") {
+		t.Error("ANSI codes not fully removed from large input")
+	}
+}
+
+func TestStripANSIEdgeCases(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"consecutive escapes", "\x1b[31m\x1b[32m\x1b[0mtext"},
+		{"escape without sequence", "\x1balone"},
+		{"partial sequences", "\x1b[\x1b]"},
+		{"null bytes", "\x1b[31m\x00text\x1b[0m"},
+		{"very long sequence", "\x1b[" + strings.Repeat("1;", 100) + "mtext\x1b[0m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should not panic or cause issues
+			result := StripANSI(tt.input)
+			_ = result // Use the result to ensure it doesn't get optimized away
+		})
+	}
+}
+
+func TestStripANSIConsistency(t *testing.T) {
+	// Ensure both implementations produce the same results
+	testCases := []string{
+		"hello world",
+		"\x1b[31mred text\x1b[0m",
+		"\x1b[1;31;40mbold red on black\x1b[0m",
+		"\x1b[2J\x1b[H\x1b[31mcomplex\x1b[0m",
+		"\x1b]0;title\x07content",
+		"\x1bP+q544e\x1b\\dcs",
+		"mixed \x1b[31mred\x1b[0m and \x1b[32mgreen\x1b[0m text",
+		"",
+		"\x1b",
+		"\x1b[",
+		"\x1b[31",
+		"real world \x1b[90m[2023-01-01 12:00:00]\x1b[0m \x1b[32m✓\x1b[0m test passed",
+	}
+
+	for _, input := range testCases {
+		t.Run("input_"+input, func(t *testing.T) {
+			regex := StripANSIRegex(input)
+			custom := StripANSI(input)
+
+			if regex != custom {
+				t.Errorf("StripANSIRegex != StripANSI for input %q: %q vs %q", input, regex, custom)
+			}
+		})
+	}
+}
+
+func TestParquetLogEntryCleanMethods(t *testing.T) {
+	tests := []struct {
+		name        string
+		entry       ParquetLogEntry
+		stripANSI   bool
+		wantContent string
+		wantGroup   string
+	}{
+		{
+			name: "no ansi, no whitespace",
+			entry: ParquetLogEntry{
+				Content: "hello world",
+				Group:   "test group",
+			},
+			stripANSI:   false,
+			wantContent: "hello world",
+			wantGroup:   "test group",
+		},
+		{
+			name: "with ansi, strip disabled",
+			entry: ParquetLogEntry{
+				Content: "\x1b[31mred text\x1b[0m",
+				Group:   "\x1b[32mgreen group\x1b[0m",
+			},
+			stripANSI:   false,
+			wantContent: "\x1b[31mred text\x1b[0m",
+			wantGroup:   "\x1b[32mgreen group\x1b[0m",
+		},
+		{
+			name: "with ansi, strip enabled",
+			entry: ParquetLogEntry{
+				Content: "\x1b[31mred text\x1b[0m",
+				Group:   "\x1b[32mgreen group\x1b[0m",
+			},
+			stripANSI:   true,
+			wantContent: "red text",
+			wantGroup:   "green group",
+		},
+		{
+			name: "with whitespace trim",
+			entry: ParquetLogEntry{
+				Content: "  \t  hello world  \n  ",
+				Group:   "  \n test group \t ",
+			},
+			stripANSI:   false,
+			wantContent: "hello world",
+			wantGroup:   "test group",
+		},
+		{
+			name: "ansi and whitespace combined",
+			entry: ParquetLogEntry{
+				Content: "  \x1b[31m  red text  \x1b[0m  ",
+				Group:   "\n  \x1b[32mgreen group\x1b[0m \t ",
+			},
+			stripANSI:   true,
+			wantContent: "red text",
+			wantGroup:   "green group",
+		},
+		{
+			name: "complex buildkite log",
+			entry: ParquetLogEntry{
+				Content: " \x1b[90m2023-01-01 12:00:00\x1b[0m \x1b[32m[INFO]\x1b[0m Starting build ",
+				Group:   " \x1b[1mTest Group\x1b[0m ",
+			},
+			stripANSI:   true,
+			wantContent: "2023-01-01 12:00:00 [INFO] Starting build",
+			wantGroup:   "Test Group",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotContent := tt.entry.CleanContent(tt.stripANSI)
+			gotGroup := tt.entry.CleanGroup(tt.stripANSI)
+
+			if gotContent != tt.wantContent {
+				t.Errorf("CleanContent() = %q, want %q", gotContent, tt.wantContent)
+			}
+			if gotGroup != tt.wantGroup {
+				t.Errorf("CleanGroup() = %q, want %q", gotGroup, tt.wantGroup)
+			}
+		})
+	}
+}

--- a/query.go
+++ b/query.go
@@ -86,6 +86,24 @@ func (entry *ParquetLogEntry) IsGroup() bool {
 	return entry.Flags.IsGroup()
 }
 
+// CleanContent returns the content with optional ANSI stripping and whitespace trimming
+func (entry *ParquetLogEntry) CleanContent(stripANSI bool) string {
+	content := entry.Content
+	if stripANSI {
+		content = StripANSI(content)
+	}
+	return strings.TrimSpace(content)
+}
+
+// CleanGroup returns the group name with optional ANSI stripping and whitespace trimming
+func (entry *ParquetLogEntry) CleanGroup(stripANSI bool) string {
+	group := entry.Group
+	if stripANSI {
+		group = StripANSI(group)
+	}
+	return strings.TrimSpace(group)
+}
+
 // GroupInfo contains statistical information about a log group
 type GroupInfo struct {
 	Name       string    `json:"name"`


### PR DESCRIPTION
To enable safe processing of log data, and reduce the number of tokens used when analysing data I have added ansi stripping.

There is a fast ansi stripper using the stringbuilder and a slower regex based implementation for comparison.

Typical logs are stripped at 1,100-1,400 MB/s which seems good enough.
