### PR TITLE
feat: add a high level client for downloading, caching, and querying Buildkite logs

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,70 @@
+package buildkitelogs
+
+import (
+	"context"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v4"
+)
+
+// ParquetClient provides a high-level convenience API for common buildkite-logs-parquet operations
+type ParquetClient struct {
+	api        BuildkiteAPI
+	storageURL string
+}
+
+// NewParquetClient creates a new ParquetClient using the provided go-buildkite client
+func NewParquetClient(client *buildkite.Client, storageURL string) *ParquetClient {
+	api := NewBuildkiteAPIExistingClient(client)
+	return &ParquetClient{
+		api:        api,
+		storageURL: storageURL,
+	}
+}
+
+// NewParquetClientWithAPI creates a new ParquetClient using a custom BuildkiteAPI implementation
+func NewParquetClientWithAPI(api BuildkiteAPI, storageURL string) *ParquetClient {
+	return &ParquetClient{
+		api:        api,
+		storageURL: storageURL,
+	}
+}
+
+// DownloadAndCache downloads and caches job logs as Parquet format, returning the local file path
+//
+// Parameters:
+//   - org: Buildkite organization slug
+//   - pipeline: Pipeline slug
+//   - build: Build number or UUID
+//   - job: Job ID
+//   - ttl: Time-to-live for cache (use 0 for default 30s)
+//   - forceRefresh: If true, forces re-download even if cache exists
+//
+// Returns the local file path of the cached Parquet file
+func (c *ParquetClient) DownloadAndCache(ctx context.Context, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (string, error) {
+	if err := ValidateAPIParams(org, pipeline, build, job); err != nil {
+		return "", err
+	}
+
+	return DownloadAndCacheBlobStorage(ctx, c.api, org, pipeline, build, job, c.storageURL, ttl, forceRefresh)
+}
+
+// NewReader downloads and caches job logs (if needed) and returns a ParquetReader for querying
+//
+// Parameters:
+//   - org: Buildkite organization slug
+//   - pipeline: Pipeline slug
+//   - build: Build number or UUID
+//   - job: Job ID
+//   - ttl: Time-to-live for cache (use 0 for default 30s)
+//   - forceRefresh: If true, forces re-download even if cache exists
+//
+// Returns a ParquetReader for querying the log data
+func (c *ParquetClient) NewReader(ctx context.Context, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (*ParquetReader, error) {
+	filePath, err := c.DownloadAndCache(ctx, org, pipeline, build, job, ttl, forceRefresh)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewParquetReader(filePath), nil
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,113 @@
+package buildkitelogs
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v4"
+)
+
+// MockBuildkiteAPI implements BuildkiteAPI for testing
+type MockBuildkiteAPI struct {
+	logContent string
+	jobStatus  *JobStatus
+}
+
+func (m *MockBuildkiteAPI) GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(m.logContent)), nil
+}
+
+func (m *MockBuildkiteAPI) GetJobStatus(org, pipeline, build, job string) (*JobStatus, error) {
+	return m.jobStatus, nil
+}
+
+func TestParquetClient_NewParquetClient(t *testing.T) {
+	// Create a mock buildkite client
+	client, _ := buildkite.NewOpts()
+	storageURL := "file://./test-cache"
+
+	parquetClient := NewParquetClient(client, storageURL)
+
+	if parquetClient == nil {
+		t.Fatal("Expected ParquetClient to be created, got nil")
+	}
+
+	if parquetClient.storageURL != storageURL {
+		t.Errorf("Expected storageURL %s, got %s", storageURL, parquetClient.storageURL)
+	}
+}
+
+func TestParquetClient_NewParquetClientWithAPI(t *testing.T) {
+	mockAPI := &MockBuildkiteAPI{
+		logContent: "test log content",
+		jobStatus: &JobStatus{
+			ID:         "test-job",
+			State:      JobStatePassed,
+			IsTerminal: true,
+		},
+	}
+	storageURL := "file://./test-cache"
+
+	parquetClient := NewParquetClientWithAPI(mockAPI, storageURL)
+
+	if parquetClient == nil {
+		t.Fatal("Expected ParquetClient to be created, got nil")
+	}
+
+	if parquetClient.api != mockAPI {
+		t.Error("Expected API to be set to mock API")
+	}
+
+	if parquetClient.storageURL != storageURL {
+		t.Errorf("Expected storageURL %s, got %s", storageURL, parquetClient.storageURL)
+	}
+}
+
+func TestParquetClient_DownloadAndCache(t *testing.T) {
+	mockAPI := &MockBuildkiteAPI{
+		logContent: "2024-01-01T00:00:00Z Test log entry\n",
+		jobStatus: &JobStatus{
+			ID:         "test-job",
+			State:      JobStatePassed,
+			IsTerminal: true,
+		},
+	}
+
+	client := NewParquetClientWithAPI(mockAPI, "file://./test-cache")
+	ctx := context.Background()
+
+	// Test parameter validation
+	_, err := client.DownloadAndCache(ctx, "", "pipeline", "build", "job", time.Minute, false)
+	if err == nil {
+		t.Error("Expected error for missing organization parameter")
+	}
+
+	// Note: Full integration test would require more setup for blob storage
+	// This tests the parameter validation and basic structure
+}
+
+func TestParquetClient_NewReader(t *testing.T) {
+	mockAPI := &MockBuildkiteAPI{
+		logContent: "2024-01-01T00:00:00Z Test log entry\n",
+		jobStatus: &JobStatus{
+			ID:         "test-job",
+			State:      JobStatePassed,
+			IsTerminal: true,
+		},
+	}
+
+	client := NewParquetClientWithAPI(mockAPI, "file://./test-cache")
+	ctx := context.Background()
+
+	// Test parameter validation
+	_, err := client.NewReader(ctx, "", "pipeline", "build", "job", time.Minute, false)
+	if err == nil {
+		t.Error("Expected error for missing organization parameter")
+	}
+
+	// Note: Full integration test would require more setup for blob storage and file creation
+	// This tests the parameter validation and basic structure
+}

--- a/examples/high-level-client/README.md
+++ b/examples/high-level-client/README.md
@@ -1,0 +1,109 @@
+# High-Level Client API Example
+
+This example demonstrates how to use the high-level `ParquetClient` API for downloading, caching, and querying Buildkite logs.
+
+## Overview
+
+The `ParquetClient` provides a simplified interface for common operations:
+
+- Download and cache job logs from Buildkite API
+- Automatic conversion to Parquet format for efficient querying
+- Support for both official `*buildkite.Client` and custom `BuildkiteAPI` implementations
+- Built-in caching with TTL and force refresh options
+
+## Prerequisites
+
+**Buildkite API Token**: Set the `BUILDKITE_API_TOKEN` environment variable:
+```bash
+export BUILDKITE_API_TOKEN="your-buildkite-api-token"
+```
+
+## Running the Example
+
+```bash
+cd examples/high-level-client
+go run main.go
+```
+
+## What the Example Does
+
+The example demonstrates three main use cases:
+
+### 1. Basic Usage with Official Client
+
+Creates a `ParquetClient` using the official `*buildkite.Client` and shows how to:
+- Download and cache logs to a local file
+- Create a reader for querying the cached data
+- Read basic file information (row count, file size, etc.)
+- Iterate through log entries
+
+### 2. Advanced Querying
+
+Shows how to use the `ParquetReader` for advanced operations:
+- Search for specific patterns in logs with context
+- Filter entries by group/section
+- Get file metadata and statistics
+
+### 3. Custom API Implementation
+
+Demonstrates how to use a custom `BuildkiteAPI` implementation instead of the official client, which is useful for:
+- Testing with mock data
+- Custom authentication or rate limiting
+- Integrating with other log sources
+
+## Configuration
+
+### Storage URLs
+
+The example uses `file://~/.bklog` as the storage URL, but you can use other backends:
+
+- **Local filesystem**: `file://./cache` or `file:///absolute/path`
+- **AWS S3**: `s3://bucket-name/path`
+- **Google Cloud Storage**: `gs://bucket-name/path`
+- **Azure Blob**: `azblob://container/path`
+
+### Caching Behavior
+
+- **TTL**: Set to 5 minutes in the example - logs are re-fetched if older than this
+- **Force Refresh**: Set to `false` - change to `true` to always re-download
+- **Terminal Jobs**: Jobs that are finished (passed/failed/canceled) are cached permanently
+
+## Key Functions
+
+### `NewParquetClient(client, storageURL)`
+
+Creates a client using the official go-buildkite client.
+
+### `NewParquetClientWithAPI(api, storageURL)`
+
+Creates a client using a custom API implementation.
+
+### `DownloadAndCache(ctx, org, pipeline, build, job, ttl, forceRefresh)`
+
+Downloads and caches logs, returns the local file path.
+
+### `NewReader(ctx, org, pipeline, build, job, ttl, forceRefresh)`
+
+Downloads/caches logs and returns a `ParquetReader` for querying.
+
+## Error Handling
+
+The client provides automatic parameter validation:
+
+```go
+// This will return an error about missing organization
+_, err := client.DownloadAndCache(ctx, "", "pipeline", "build", "job", 0, false)
+```
+
+## Integration with Other Examples
+
+This high-level API works well with other examples in this repository:
+
+- Use the cached Parquet files with the [query example](../query/) for advanced searching
+- Integrate with the [smart-cache example](../smart-cache/) for more sophisticated caching strategies
+
+## Next Steps
+
+- Check out the [detailed API documentation](../../docs/client-api.md)
+- See the main [README](../../README.md) for more usage patterns
+- Explore the low-level API for advanced use cases

--- a/examples/high-level-client/main.go
+++ b/examples/high-level-client/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/buildkite/go-buildkite/v4"
+	buildkitelogs "github.com/wolfeidau/buildkite-logs-parquet"
+)
+
+func main() {
+	// Get API token from environment
+	apiToken := os.Getenv("BUILDKITE_API_TOKEN")
+	if apiToken == "" {
+		log.Fatal("BUILDKITE_API_TOKEN environment variable is required")
+	}
+
+	// Create buildkite client
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(apiToken))
+	if err != nil {
+		log.Fatal("Failed to create buildkite client:", err)
+	}
+
+	// Create high-level ParquetClient
+	storageURL := "file://~/.bklog" // Uses default storage location
+	parquetClient := buildkitelogs.NewParquetClient(client, storageURL)
+
+	ctx := context.Background()
+	org := "myorg"
+	pipeline := "mypipeline"
+	build := "123"
+	job := "abc-123-def"
+
+	// Example 1: Just download and cache logs
+	fmt.Println("Downloading and caching logs...")
+	filePath, err := parquetClient.DownloadAndCache(ctx, org, pipeline, build, job, time.Minute*5, false)
+	if err != nil {
+		log.Fatal("Failed to download and cache:", err)
+	}
+	fmt.Printf("Cached to: %s\n", filePath)
+
+	// Example 2: Get a reader and query the logs
+	fmt.Println("Creating reader and querying logs...")
+	reader, err := parquetClient.NewReader(ctx, org, pipeline, build, job, time.Minute*5, false)
+	if err != nil {
+		log.Fatal("Failed to create reader:", err)
+	}
+
+	// Get file info
+	info, err := reader.GetFileInfo()
+	if err != nil {
+		log.Fatal("Failed to get file info:", err)
+	}
+	fmt.Printf("Log file contains %d rows\n", info.RowCount)
+
+	// Read first 10 entries
+	count := 0
+	for entry, err := range reader.ReadEntriesIter() {
+		if err != nil {
+			log.Fatal("Error reading entries:", err)
+		}
+
+		fmt.Printf("Entry %d: %s\n", count+1, entry.Content)
+		count++
+		if count >= 10 {
+			break
+		}
+	}
+
+	// Example 3: Using with custom API implementation
+	fmt.Println("\nExample with custom API:")
+	customAPI := &CustomBuildkiteAPI{} // Your custom implementation
+	customClient := buildkitelogs.NewParquetClientWithAPI(customAPI, storageURL)
+
+	reader2, err := customClient.NewReader(ctx, org, pipeline, build, job, time.Minute*5, false)
+	if err != nil {
+		log.Fatal("Failed to create reader with custom API:", err)
+	}
+
+	// Search for specific patterns
+	searchOpts := buildkitelogs.SearchOptions{
+		Pattern:       "error",
+		Context:       2,
+		CaseSensitive: false,
+	}
+
+	fmt.Println("Searching for 'error' in logs:")
+	for result, err := range reader2.SearchEntriesIter(searchOpts) {
+		if err != nil {
+			log.Fatal("Error searching:", err)
+		}
+		fmt.Printf("Found error at row %d: %s\n", result.LineNumber, result.Match.Content)
+		break // Just show first result
+	}
+}
+
+// CustomBuildkiteAPI is an example custom implementation
+type CustomBuildkiteAPI struct {
+	// Your custom implementation fields
+}
+
+func (c *CustomBuildkiteAPI) GetJobLog(org, pipeline, build, job string) (io.ReadCloser, error) {
+	// Your custom log fetching logic
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (c *CustomBuildkiteAPI) GetJobStatus(org, pipeline, build, job string) (*buildkitelogs.JobStatus, error) {
+	// Your custom job status logic
+	return nil, fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
The `ParquetClient` provides:
- **Simplified API**: Easy-to-use methods for common operations
- **Automatic caching**: Intelligent caching with TTL support
- **Multiple backends**: Support for both official `*buildkite.Client` and custom `BuildkiteAPI` implementations
- **Parameter validation**: Built-in validation with descriptive error messages
