### PR TITLE
chore: remove command matching as it is now possible with search

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This parser extracts the timestamps and content, providing both a Go library API
 - **Timestamp Extraction**: Converts millisecond timestamps to Go `time.Time` objects
 - **ANSI Code Handling**: Optional stripping of ANSI escape sequences for clean text output
 - **Content Classification**: Automatically identifies different types of log entries:
-  - Commands (lines starting with `$`)
+  
   - Section headers (lines starting with `~~~`, `---`, or `+++`)
 - **Multiple Data Sources**: Local files and Buildkite API integration
 - **Buildkite API**: Fetch logs directly from Buildkite jobs via REST API
@@ -81,9 +81,9 @@ goreleaser build --snapshot --clean --single-target
 ./build/bklog parse -file buildkite.log -strip-ansi
 ```
 
-**Output only commands:**
+**Output only sections:**
 ```bash
-./build/bklog parse -file buildkite.log -filter command -strip-ansi
+./build/bklog parse -file buildkite.log -filter section -strip-ansi
 ```
 
 **Output only group headers:**
@@ -110,10 +110,10 @@ export BUILDKITE_API_TOKEN="bkua_your_token_here"
 ./build/bklog parse -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -parquet logs.parquet -summary
 ```
 
-**Filter and export only commands from API:**
+**Filter and export only sections from API:**
 ```bash
 export BUILDKITE_API_TOKEN="bkua_your_token_here"
-./build/bklog parse -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -filter command -json
+./build/bklog parse -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -filter section -json
 ```
 
 **Show processing statistics:**
@@ -126,7 +126,7 @@ Output:
 Bytes processed: 24.4 KB
 Total entries: 212
 Entries with timestamps: 212
-Commands: 15
+
 Sections: 13
 Regular output: 184
 ```
@@ -154,7 +154,7 @@ Output:
 Bytes processed: 24.4 KB
 Total entries: 212
 Entries with timestamps: 212
-Commands: 15
+
 Sections: 13
 Regular output: 184
 Exported 212 entries to output.parquet
@@ -162,9 +162,9 @@ Exported 212 entries to output.parquet
 
 **Export filtered data to Parquet:**
 ```bash
-./build/bklog -file buildkite.log -parquet commands.parquet -filter command -summary
+./build/bklog -file buildkite.log -parquet sections.parquet -filter section -summary
 ```
-This exports only command entries to a smaller Parquet file for analysis.
+This exports only section entries to a smaller Parquet file for analysis.
 
 ### Querying Parquet Files
 
@@ -178,7 +178,7 @@ Output:
 ```
 Groups found: 5
 
-GROUP NAME                                ENTRIES COMMANDS          FIRST SEEN           LAST SEEN
+GROUP NAME                                ENTRIES          FIRST SEEN           LAST SEEN
 ------------------------------------------------------------------------------------------------------------
 ~~~ Running global environment hook             2        1 2025-04-22 21:43:29 2025-04-22 21:43:29
 ~~~ Running global pre-checkout hook            2        1 2025-04-22 21:43:29 2025-04-22 21:43:29
@@ -365,7 +365,7 @@ export BUILDKITE_API_TOKEN="bkua_your_token_here"
 ./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op list-groups
 ```
 
-**Query commands directly from Buildkite API:**
+**Query logs directly from Buildkite API:**
 ```bash
 export BUILDKITE_API_TOKEN="bkua_your_token_here"
 ./build/bklog query -org myorg -pipeline mypipeline -build 123 -job abc-def-456 -op list-commands

--- a/cmd/bklog/debug_cli.go
+++ b/cmd/bklog/debug_cli.go
@@ -197,7 +197,6 @@ func showParseDebug(parser *buildkitelogs.Parser, line string, config *DebugConf
 			fmt.Printf("Content: %q\n", entry.Content)
 			fmt.Printf("Group: %q\n", entry.Group)
 			fmt.Printf("RawLine length: %d\n", len(entry.RawLine))
-			fmt.Printf("IsCommand: %v\n", entry.IsCommand())
 			fmt.Printf("IsGroup: %v\n", entry.IsGroup())
 		} else {
 			if !entry.Timestamp.IsZero() {

--- a/cmd/bklog/main.go
+++ b/cmd/bklog/main.go
@@ -29,7 +29,6 @@ type ProcessingSummary struct {
 	FilteredEntries int
 	BytesProcessed  int64
 	EntriesWithTime int
-	Commands        int
 	Sections        int
 }
 

--- a/cmd/bklog/parse_cli.go
+++ b/cmd/bklog/parse_cli.go
@@ -187,9 +187,7 @@ func outputJSONSeq2(reader io.Reader, parser *buildkitelogs.Parser, filter strin
 		if entry.HasTimestamp() {
 			summary.EntriesWithTime++
 		}
-		if entry.IsCommand() {
-			summary.Commands++
-		}
+
 		if entry.IsGroup() {
 			summary.Sections++
 		}
@@ -235,9 +233,7 @@ func outputTextSeq2(reader io.Reader, parser *buildkitelogs.Parser, filter strin
 		if entry.HasTimestamp() {
 			summary.EntriesWithTime++
 		}
-		if entry.IsCommand() {
-			summary.Commands++
-		}
+
 		if entry.IsGroup() {
 			summary.Sections++
 		}
@@ -271,7 +267,7 @@ func outputTextSeq2(reader io.Reader, parser *buildkitelogs.Parser, filter strin
 func shouldIncludeEntry(entry *buildkitelogs.LogEntry, filter string) bool {
 	switch filter {
 	case "command":
-		return entry.IsCommand()
+		return false // Commands filter no longer supported
 	case "group", "section": // Support both for backward compatibility
 		return entry.IsGroup()
 	default:
@@ -309,9 +305,7 @@ func exportToParquetSeq2(reader io.Reader, parser *buildkitelogs.Parser, filenam
 			if entry.HasTimestamp() {
 				summary.EntriesWithTime++
 			}
-			if entry.IsCommand() {
-				summary.Commands++
-			}
+
 			if entry.IsGroup() {
 				summary.Sections++
 			}
@@ -367,9 +361,7 @@ func exportToJSONLSeq2(reader io.Reader, parser *buildkitelogs.Parser, filename 
 		if entry.HasTimestamp() {
 			summary.EntriesWithTime++
 		}
-		if entry.IsCommand() {
-			summary.Commands++
-		}
+
 		if entry.IsGroup() {
 			summary.Sections++
 		}
@@ -404,9 +396,8 @@ func printSummary(summary *ProcessingSummary) {
 	}
 	fmt.Printf("Total entries: %d\n", summary.TotalEntries)
 	fmt.Printf("Entries with timestamps: %d\n", summary.EntriesWithTime)
-	fmt.Printf("Commands: %d\n", summary.Commands)
 	fmt.Printf("Sections: %d\n", summary.Sections)
-	fmt.Printf("Regular output: %d\n", summary.TotalEntries-summary.Commands-summary.Sections)
+	fmt.Printf("Regular output: %d\n", summary.TotalEntries-summary.Sections)
 
 	if summary.FilteredEntries > 0 {
 		fmt.Printf("Exported %d entries to %s\n", summary.FilteredEntries, "Parquet file")

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -56,17 +56,14 @@ func main() {
 			info.LastSeen = entryTime
 		}
 
-		if entry.IsCommand() {
-			info.Commands++
-		}
 	}
 
 	fmt.Printf("Processed %d total entries\n", totalEntries)
 	i := 1
 	for name, info := range groupMap {
 		if i <= 3 { // Show first 3 groups
-			fmt.Printf("%d. %s (%d entries, %d commands)\n",
-				i, name, info.EntryCount, info.Commands)
+			fmt.Printf("%d. %s (%d entries)\n",
+				i, name, info.EntryCount)
 		}
 		i++
 		if i > 3 {

--- a/iter_test.go
+++ b/iter_test.go
@@ -123,31 +123,31 @@ func TestIterSeq2WithFiltering(t *testing.T) {
 
 	reader := strings.NewReader(testData)
 
-	// Filter for commands only
-	commands := []string{}
+	// Filter for entries containing '$' (command pattern)
+	dollarEntries := []string{}
 
 	for entry, err := range parser.All(reader) {
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		if entry.IsCommand() {
-			commands = append(commands, entry.Content)
+		if strings.Contains(entry.Content, "$") {
+			dollarEntries = append(dollarEntries, entry.Content)
 		}
 	}
 
-	expectedCommands := []string{
+	expectedDollarEntries := []string{
 		"$ /buildkite/agent/hooks/environment",
 		"$ git clone repo",
 	}
 
-	if len(commands) != len(expectedCommands) {
-		t.Fatalf("Expected %d commands, got %d", len(expectedCommands), len(commands))
+	if len(dollarEntries) != len(expectedDollarEntries) {
+		t.Fatalf("Expected %d entries with '$', got %d", len(expectedDollarEntries), len(dollarEntries))
 	}
 
-	for i, cmd := range commands {
-		if cmd != expectedCommands[i] {
-			t.Errorf("Command %d: expected %q, got %q", i, expectedCommands[i], cmd)
+	for i, entry := range dollarEntries {
+		if entry != expectedDollarEntries[i] {
+			t.Errorf("Dollar entry %d: expected %q, got %q", i, expectedDollarEntries[i], entry)
 		}
 	}
 }

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -107,9 +107,9 @@ func TestParquetSeq2ExportWithFilter(t *testing.T) {
 
 	reader := strings.NewReader(testData)
 
-	// Filter for commands only
+	// Filter for entries containing '$'
 	filterFunc := func(entry *LogEntry) bool {
-		return entry.IsCommand()
+		return strings.Contains(entry.Content, "$")
 	}
 
 	// Export using Seq2 with filter
@@ -130,7 +130,7 @@ func TestParquetSeq2ExportWithFilter(t *testing.T) {
 		_ = os.Remove(filename)
 	}()
 
-	// Check file is not empty (should contain 2 command entries)
+	// Check file is not empty (should contain 2 entries with '$')
 	info, err := os.Stat(filename)
 	if err != nil {
 		t.Fatalf("Failed to stat parquet file: %v", err)

--- a/parser.go
+++ b/parser.go
@@ -147,11 +147,6 @@ func (entry *LogEntry) HasTimestamp() bool {
 	return !entry.Timestamp.IsZero()
 }
 
-// IsCommand returns true if the log entry appears to be a command execution
-func (entry *LogEntry) IsCommand() bool {
-	return strings.HasPrefix(entry.Content, "$ ")
-}
-
 // IsGroup returns true if the log entry appears to be a group header
 func (entry *LogEntry) IsGroup() bool {
 	return strings.HasPrefix(entry.Content, "~~~ ") || strings.HasPrefix(entry.Content, "--- ") || strings.HasPrefix(entry.Content, "+++ ")
@@ -167,9 +162,6 @@ func (entry *LogEntry) ComputeFlags() LogFlags {
 	var flags LogFlags
 	if entry.HasTimestamp() {
 		flags.Set(HasTimestamp)
-	}
-	if entry.IsCommand() {
-		flags.Set(IsCommand)
 	}
 	if entry.IsGroup() {
 		flags.Set(IsGroup)

--- a/parser_bench_test.go
+++ b/parser_bench_test.go
@@ -153,7 +153,6 @@ func BenchmarkIteratorWithFiltering(b *testing.B) {
 		name string
 		fn   func(*LogEntry) bool
 	}{
-		{"commands", func(e *LogEntry) bool { return e.IsCommand() }},
 		{"sections", func(e *LogEntry) bool { return e.IsSection() }},
 	}
 
@@ -264,7 +263,6 @@ func BenchmarkSeq2WithFiltering(b *testing.B) {
 		name string
 		fn   func(*LogEntry) bool
 	}{
-		{"commands", func(e *LogEntry) bool { return e.IsCommand() }},
 		{"groups", func(e *LogEntry) bool { return e.IsGroup() }},
 	}
 
@@ -360,7 +358,7 @@ func BenchmarkParquetWithFiltering(b *testing.B) {
 	parser := NewParser()
 
 	filterFunc := func(entry *LogEntry) bool {
-		return entry.IsCommand() || entry.IsGroup()
+		return entry.IsGroup()
 	}
 
 	b.Run("seq2_filtered", func(b *testing.B) {
@@ -419,15 +417,6 @@ func BenchmarkContentClassification(b *testing.B) {
 		}
 		entries = append(entries, entry)
 	}
-
-	b.Run("is_command", func(b *testing.B) {
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			for _, entry := range entries {
-				_ = entry.IsCommand()
-			}
-		}
-	})
 
 	b.Run("is_group", func(b *testing.B) {
 		b.ResetTimer()

--- a/parser_test.go
+++ b/parser_test.go
@@ -81,31 +81,26 @@ func TestLogEntryClassification(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
-		wantCommand bool
 		wantSection bool
 	}{
 		{
 			name:        "Command with ANSI",
 			input:       "\x1b_bk;t=1745322209921\x07[90m$[0m /buildkite/agent/hooks/environment",
-			wantCommand: false,
 			wantSection: false,
 		},
 		{
 			name:        "Section header",
 			input:       "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook",
-			wantCommand: false,
 			wantSection: true,
 		},
 		{
 			name:        "Build artifact section",
 			input:       "\x1b_bk;t=1745322210701\x07+++ :frame_with_picture: Inline image uploaded",
-			wantCommand: false,
 			wantSection: true,
 		},
 		{
 			name:        "Regular output",
 			input:       "\x1b_bk;t=1745322210701\x07Cloning into '.'...",
-			wantCommand: false,
 			wantSection: false,
 		},
 	}
@@ -115,10 +110,6 @@ func TestLogEntryClassification(t *testing.T) {
 			entry, err := parser.ParseLine(tt.input)
 			if err != nil {
 				t.Fatalf("ParseLine() error = %v", err)
-			}
-
-			if entry.IsCommand() != tt.wantCommand {
-				t.Errorf("IsCommand() = %v, want %v", entry.IsCommand(), tt.wantCommand)
 			}
 
 			if entry.IsSection() != tt.wantSection {
@@ -163,9 +154,6 @@ func TestParseReader(t *testing.T) {
 	// Check second entry
 	if !entries[1].HasTimestamp() {
 		t.Error("Second entry should have timestamp")
-	}
-	if entries[1].IsCommand() {
-		t.Error("Second entry should not be a command (ANSI codes present)")
 	}
 
 	// Check third entry (regular line)
@@ -215,9 +203,6 @@ func TestLogIterator(t *testing.T) {
 	entry = iterator.Entry()
 	if !entry.HasTimestamp() {
 		t.Error("Second entry should have timestamp")
-	}
-	if entry.IsCommand() {
-		t.Error("Second entry should not be a command (ANSI codes present)")
 	}
 
 	// Test third entry (regular line)

--- a/query.go
+++ b/query.go
@@ -21,7 +21,6 @@ type LogFlag int32
 
 const (
 	HasTimestamp LogFlag = iota
-	IsCommand
 	IsGroup
 )
 
@@ -53,11 +52,6 @@ func (lf LogFlags) HasTimestamp() bool {
 	return lf.Has(HasTimestamp)
 }
 
-// IsCommand returns true if IsCommand flag is set
-func (lf LogFlags) IsCommand() bool {
-	return lf.Has(IsCommand)
-}
-
 // IsGroup returns true if IsGroup flag is set
 func (lf LogFlags) IsGroup() bool {
 	return lf.Has(IsGroup)
@@ -75,11 +69,6 @@ type ParquetLogEntry struct {
 // HasTime returns true if the entry has a timestamp (backward compatibility)
 func (entry *ParquetLogEntry) HasTime() bool {
 	return entry.Flags.HasTimestamp()
-}
-
-// IsCommand returns true if the entry is a command (backward compatibility)
-func (entry *ParquetLogEntry) IsCommand() bool {
-	return entry.Flags.IsCommand()
 }
 
 // IsGroup returns true if the entry is a group header (backward compatibility)
@@ -111,7 +100,6 @@ type GroupInfo struct {
 	EntryCount int       `json:"entry_count"`
 	FirstSeen  time.Time `json:"first_seen"`
 	LastSeen   time.Time `json:"last_seen"`
-	Commands   int       `json:"commands"`
 }
 
 // SearchOptions configures regex search behavior

--- a/query_bench_test.go
+++ b/query_bench_test.go
@@ -117,9 +117,6 @@ func BenchmarkStreamingGroupAnalysis(b *testing.B) {
 			}
 
 			info.EntryCount++
-			if entry.IsCommand() {
-				info.Commands++
-			}
 		}
 
 		if len(groupMap) == 0 {
@@ -349,9 +346,6 @@ func BenchmarkStreamingScalability(b *testing.B) {
 				}
 				// Complex processing: build statistics
 				groupStats[entry.Group]++
-				if entry.IsCommand() {
-					groupStats[entry.Group+"_commands"]++
-				}
 			}
 		}
 	})

--- a/query_test.go
+++ b/query_test.go
@@ -111,9 +111,6 @@ func TestParquetReader(t *testing.T) {
 			}
 
 			info.EntryCount++
-			if entry.IsCommand() {
-				info.Commands++
-			}
 
 			// Stop after processing some entries for test performance
 			if totalEntries >= 100 {
@@ -178,7 +175,7 @@ func TestStreamingGroupAnalysis(t *testing.T) {
 			Timestamp: baseTime + 100,
 			Content:   "$ npm test",
 			Group:     "~~~ Running tests",
-			Flags:     LogFlags(1 << IsCommand),
+			Flags:     0,
 		},
 		{
 			Timestamp: baseTime + 1000,
@@ -217,9 +214,6 @@ func TestStreamingGroupAnalysis(t *testing.T) {
 			info.LastSeen = entryTime
 		}
 
-		if entry.IsCommand() {
-			info.Commands++
-		}
 	}
 
 	if len(groupMap) != 2 {
@@ -233,9 +227,6 @@ func TestStreamingGroupAnalysis(t *testing.T) {
 	}
 	if testsGroup.EntryCount != 2 {
 		t.Errorf("Expected entry count 2, got %d", testsGroup.EntryCount)
-	}
-	if testsGroup.Commands != 1 {
-		t.Errorf("Expected 1 command, got %d", testsGroup.Commands)
 	}
 }
 

--- a/streaming_bench_test.go
+++ b/streaming_bench_test.go
@@ -124,9 +124,6 @@ func BenchmarkStreamingFiles(b *testing.B) {
 					}
 
 					info.EntryCount++
-					if entry.IsCommand() {
-						info.Commands++
-					}
 				}
 				_ = groupMap
 			}


### PR DESCRIPTION
The patterns for locating sequences in the logs is now usable via the query search with a pattern.

There are a myriad of other useful patterns and I am keen to push those up a level.
