### PR TITLE
feat: add a log debugger which emits csv file of OSC timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 /cover*
 /PRD
 /docs
+/*.csv


### PR DESCRIPTION
This enables some good insights around timestamp distribution in the logs.

<img width="959" height="550" alt="Screenshot 2025-08-01 at 7 19 05 am" src="https://github.com/user-attachments/assets/34be5d74-4663-4f4b-bccc-504d4ff5f8b0" />
