### PR TITLE
refactor: pass context at call sites instead of storing in ParquetReader

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func (c *Client) NewReader(ctx context.Context, org, pipeline, build, job string
 		return nil, err
 	}
 
-	return newParquetReaderOwned(ctx, filePath), nil
+	return newParquetReaderOwned(filePath), nil
 }
 
 // downloadAndCache downloads and caches job logs as Parquet format, returning the local file path.

--- a/client_test.go
+++ b/client_test.go
@@ -262,7 +262,7 @@ func TestClient_NewReader_ReadEntries(t *testing.T) {
 
 	// Verify we can read entries from the reader
 	count := 0
-	for _, err := range reader.ReadEntriesIter() {
+	for _, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
 			t.Fatalf("ReadEntriesIter: %v", err)
 		}

--- a/cmd/bklog/query_cli.go
+++ b/cmd/bklog/query_cli.go
@@ -289,14 +289,14 @@ func runQuery(ctx context.Context, config *QueryConfig) error {
 	}
 	defer reader.Close()
 
-	return runStreamingQuery(reader, config)
+	return runStreamingQuery(ctx, reader, config)
 }
 
 // resolveReader creates a ParquetReader from either a local file or the Buildkite API.
 func resolveReader(ctx context.Context, config *QueryConfig) (*buildkitelogs.ParquetReader, error) {
 	// If file path is provided directly, use it (non-owned reader)
 	if config.ParquetFile != "" {
-		return buildkitelogs.NewParquetReader(ctx, config.ParquetFile), nil
+		return buildkitelogs.NewParquetReader(config.ParquetFile), nil
 	}
 
 	// If API parameters are provided, download and cache using high-level client
@@ -326,12 +326,12 @@ func resolveReader(ctx context.Context, config *QueryConfig) (*buildkitelogs.Par
 }
 
 // runStreamingQuery executes streaming queries for memory efficiency
-func runStreamingQuery(reader *buildkitelogs.ParquetReader, config *QueryConfig) error {
+func runStreamingQuery(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig) error {
 	start := time.Now()
 
 	switch config.Operation {
 	case "list-groups":
-		return streamListGroups(reader, config, start)
+		return streamListGroups(ctx, reader, config, start)
 
 	case "info":
 		return showFileInfo(reader, config)
@@ -339,30 +339,30 @@ func runStreamingQuery(reader *buildkitelogs.ParquetReader, config *QueryConfig)
 		if config.GroupName == "" {
 			return fmt.Errorf("group pattern is required for by-group operation")
 		}
-		return streamByGroup(reader, config, start)
+		return streamByGroup(ctx, reader, config, start)
 	case "search":
 		if config.SearchPattern == "" {
 			return fmt.Errorf("pattern is required for search operation")
 		}
-		return streamSearch(reader, config, start)
+		return streamSearch(ctx, reader, config, start)
 	case "tail":
-		return tailFile(reader, config, start)
+		return tailFile(ctx, reader, config, start)
 	case "seek":
-		return seekToRow(reader, config, start)
+		return seekToRow(ctx, reader, config, start)
 	case "dump":
-		return streamDump(reader, config, start)
+		return streamDump(ctx, reader, config, start)
 	default:
 		return fmt.Errorf("unknown operation: %s", config.Operation)
 	}
 }
 
 // streamListGroups handles list-groups operation using streaming
-func streamListGroups(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func streamListGroups(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	// Use streaming iterator to build group statistics
 	groupMap := make(map[string]*buildkitelogs.GroupInfo)
 	totalEntries := 0
 
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
 			return fmt.Errorf("error reading entries: %w", err)
 		}
@@ -414,11 +414,11 @@ func streamListGroups(reader *buildkitelogs.ParquetReader, config *QueryConfig, 
 
 	// Format output
 	queryTime := float64(time.Since(start).Nanoseconds()) / 1e6
-	return formatStreamingGroupsResult(groups, totalEntries, queryTime, config)
+	return formatStreamingGroupsResult(ctx, groups, totalEntries, queryTime, config)
 }
 
 // streamSearch handles search operation using streaming with regex pattern matching and context lines
-func streamSearch(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func streamSearch(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	// Create search options
 	options := buildkitelogs.SearchOptions{
 		Pattern:       config.SearchPattern,
@@ -434,7 +434,7 @@ func streamSearch(reader *buildkitelogs.ParquetReader, config *QueryConfig, star
 	var results []buildkitelogs.SearchResult
 	matchesFound := 0
 
-	for result, err := range reader.SearchEntriesIter(options) {
+	for result, err := range reader.SearchEntriesIter(ctx, options) {
 		if err != nil {
 			return fmt.Errorf("error during search: %w", err)
 		}
@@ -454,12 +454,12 @@ func streamSearch(reader *buildkitelogs.ParquetReader, config *QueryConfig, star
 }
 
 // streamByGroup handles by-group operation using streaming with optional limiting
-func streamByGroup(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func streamByGroup(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	var entries []buildkitelogs.ParquetLogEntry
 	totalEntries := 0
 	matchedEntries := 0
 
-	for entry, err := range reader.FilterByGroupIter(config.GroupName) {
+	for entry, err := range reader.FilterByGroupIter(ctx, config.GroupName) {
 		if err != nil {
 			return fmt.Errorf("error filtering entries: %w", err)
 		}
@@ -476,7 +476,7 @@ func streamByGroup(reader *buildkitelogs.ParquetReader, config *QueryConfig, sta
 
 	// Count total entries for stats if needed (requires separate iteration)
 	if config.ShowStats {
-		for range reader.ReadEntriesIter() {
+		for range reader.ReadEntriesIter(ctx) {
 			totalEntries++
 		}
 	}
@@ -497,7 +497,7 @@ func writeJSONLines[T any](entries []T, writer io.Writer) error {
 }
 
 // formatStreamingGroupsResult formats groups output from streaming query
-func formatStreamingGroupsResult(groups []buildkitelogs.GroupInfo, totalEntries int, queryTime float64, config *QueryConfig) error {
+func formatStreamingGroupsResult(ctx context.Context, groups []buildkitelogs.GroupInfo, totalEntries int, queryTime float64, config *QueryConfig) error {
 	if config.Format == "json" {
 		return writeJSONLines(groups, io.Writer(os.Stdout))
 	}
@@ -623,7 +623,7 @@ func showFileInfo(reader *buildkitelogs.ParquetReader, config *QueryConfig) erro
 }
 
 // tailFile shows the last N entries from the file
-func tailFile(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func tailFile(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	// Get file info to calculate starting position
 	info, err := reader.GetFileInfo()
 	if err != nil {
@@ -644,7 +644,7 @@ func tailFile(reader *buildkitelogs.ParquetReader, config *QueryConfig, start ti
 	var entries []buildkitelogs.ParquetLogEntry
 	entriesRead := 0
 
-	for entry, err := range reader.SeekToRow(startRow) {
+	for entry, err := range reader.SeekToRow(ctx, startRow) {
 		if err != nil {
 			return fmt.Errorf("error reading entries: %w", err)
 		}
@@ -664,11 +664,11 @@ func tailFile(reader *buildkitelogs.ParquetReader, config *QueryConfig, start ti
 }
 
 // seekToRow starts reading from a specific row
-func seekToRow(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func seekToRow(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	var entries []buildkitelogs.ParquetLogEntry
 	entriesRead := 0
 
-	for entry, err := range reader.SeekToRow(config.SeekToRow) {
+	for entry, err := range reader.SeekToRow(ctx, config.SeekToRow) {
 		if err != nil {
 			return fmt.Errorf("error reading entries: %w", err)
 		}
@@ -738,11 +738,11 @@ func formatSeekResult(entries []buildkitelogs.ParquetLogEntry, startRow, entries
 }
 
 // streamDump handles dump operation using streaming to output all entries
-func streamDump(reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
+func streamDump(ctx context.Context, reader *buildkitelogs.ParquetReader, config *QueryConfig, start time.Time) error {
 	var entries []buildkitelogs.ParquetLogEntry
 	totalEntries := 0
 
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
 			return fmt.Errorf("error reading entries: %w", err)
 		}

--- a/examples/high-level-client/main.go
+++ b/examples/high-level-client/main.go
@@ -13,6 +13,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	// Get API token from environment
 	apiToken := os.Getenv("BUILDKITE_API_TOKEN")
 	if apiToken == "" {
@@ -24,8 +26,6 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to create buildkite client:", err)
 	}
-
-	ctx := context.Background()
 
 	// Create high-level Client
 	storageURL := "file://~/.bklog" // Uses default storage location
@@ -87,7 +87,7 @@ func main() {
 
 	// Read first 10 entries
 	count := 0
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
 			log.Printf("Error reading entries: %v", err)
 			return
@@ -125,7 +125,7 @@ func main() {
 	}
 
 	fmt.Println("Searching for 'error' in logs:")
-	for result, err := range reader2.SearchEntriesIter(searchOpts) {
+	for result, err := range reader2.SearchEntriesIter(ctx, searchOpts) {
 		if err != nil {
 			log.Printf("Error searching: %v", err)
 			return

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -13,8 +13,10 @@ import (
 func main() {
 	// Example: Using the ParquetReader to stream query Buildkite logs
 
+	ctx := context.Background()
+
 	// Create a new reader for your Parquet file
-	reader := buildkitelogs.NewParquetReader(context.Background(), "../../test_logs.parquet")
+	reader := buildkitelogs.NewParquetReader("../../test_logs.parquet")
 
 	fmt.Println("🔍 Buildkite Logs Parquet Streaming Query Example")
 	fmt.Println(strings.Repeat("=", 50))
@@ -24,7 +26,7 @@ func main() {
 	groupMap := make(map[string]*buildkitelogs.GroupInfo)
 	totalEntries := 0
 
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
 			log.Fatalf("Failed to read entries: %v", err)
 		}
@@ -76,7 +78,7 @@ func main() {
 	fmt.Println("\n🔎 Streaming entries containing 'environment':")
 	environmentCount := 0
 
-	for entry, err := range reader.FilterByGroupIter("environment") {
+	for entry, err := range reader.FilterByGroupIter(ctx, "environment") {
 		if err != nil {
 			log.Fatalf("Failed to filter by group: %v", err)
 		}
@@ -93,7 +95,7 @@ func main() {
 	fmt.Println("\n📖 Streaming entries directly from file:")
 	directCount := 0
 
-	for _, err := range buildkitelogs.ReadParquetFileIter(context.Background(), "../../test_logs.parquet") {
+	for _, err := range buildkitelogs.ReadParquetFileIter(ctx, "../../test_logs.parquet") {
 		if err != nil {
 			log.Fatalf("Failed to read Parquet file: %v", err)
 		}
@@ -110,7 +112,7 @@ func main() {
 	fmt.Println("\n🔧 Streaming with early termination:")
 	testCount := 0
 
-	for _, err := range reader.FilterByGroupIter("test") {
+	for _, err := range reader.FilterByGroupIter(ctx, "test") {
 		if err != nil {
 			log.Fatalf("Failed to filter entries: %v", err)
 		}

--- a/parquet.go
+++ b/parquet.go
@@ -18,8 +18,6 @@ func createNewFileWriter(schema *arrow.Schema, file *os.File, pool memory.Alloca
 	writer, err := pqarrow.NewFileWriter(schema, file,
 		parquet.NewWriterProperties(
 			parquet.WithCompression(compress.Codecs.Zstd),
-			parquet.WithCompressionLevel(5),
-			// Removed sorting to preserve insertion order
 		),
 		pqarrow.NewArrowWriterProperties(
 			pqarrow.WithAllocator(pool),
@@ -160,7 +158,7 @@ func ExportSeq2ToParquetWithFilter(seq iter.Seq2[*LogEntry, error], filename str
 	}
 	defer func() { _ = writer.Close() }()
 
-	const batchSize = 10000
+	const batchSize = 1000
 	batch := make([]*LogEntry, 0, batchSize)
 
 	for entry, err := range seq {

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -102,9 +102,9 @@ func TestParquetWriterMultipleBatches(t *testing.T) {
 	}
 
 	// Verify all 15 entries round-trip
-	reader := NewParquetReader(context.Background(), filename)
+	reader := NewParquetReader(filename)
 	var count int
-	for _, err := range reader.ReadEntriesIter() {
+	for _, err := range reader.ReadEntriesIter(t.Context()) {
 		if err != nil {
 			t.Fatalf("ReadEntriesIter error: %v", err)
 		}
@@ -141,9 +141,9 @@ func TestParquetRoundtrip(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 	var results []ParquetLogEntry
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(t.Context()) {
 		if err != nil {
 			t.Fatalf("ReadEntriesIter failed: %v", err)
 		}
@@ -213,9 +213,9 @@ func TestParquetRoundtripRowNumbers(t *testing.T) {
 		t.Fatalf("Close failed: %v", err)
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 	var rowNumbers []int64
-	for entry, err := range reader.ReadEntriesIter() {
+	for entry, err := range reader.ReadEntriesIter(t.Context()) {
 		if err != nil {
 			t.Fatalf("ReadEntriesIter failed: %v", err)
 		}

--- a/query.go
+++ b/query.go
@@ -146,25 +146,22 @@ type ParquetFileInfo struct {
 
 // ParquetReader provides functionality to read and query Parquet log files
 type ParquetReader struct {
-	ctx      context.Context
 	filename string
 	owned    bool // if true, Close() removes the file (it's a temp file we created)
 }
 
 // NewParquetReader creates a new ParquetReader for the specified file.
 // The caller retains ownership of the file; Close() is a no-op.
-func NewParquetReader(ctx context.Context, filename string) *ParquetReader {
+func NewParquetReader(filename string) *ParquetReader {
 	return &ParquetReader{
-		ctx:      ctx,
 		filename: filename,
 	}
 }
 
 // newParquetReaderOwned creates a ParquetReader that owns the underlying file.
 // Close() will remove the file.
-func newParquetReaderOwned(ctx context.Context, filename string) *ParquetReader {
+func newParquetReaderOwned(filename string) *ParquetReader {
 	return &ParquetReader{
-		ctx:      ctx,
 		filename: filename,
 		owned:    true,
 	}
@@ -180,18 +177,18 @@ func (pr *ParquetReader) Close() error {
 }
 
 // ReadEntriesIter returns an iterator over log entries from the Parquet file
-func (pr *ParquetReader) ReadEntriesIter() iter.Seq2[ParquetLogEntry, error] {
-	return readParquetFileIter(pr.ctx, pr.filename)
+func (pr *ParquetReader) ReadEntriesIter(ctx context.Context) iter.Seq2[ParquetLogEntry, error] {
+	return readParquetFileIter(ctx, pr.filename)
 }
 
 // FilterByGroupIter returns an iterator over entries that belong to groups matching the specified name pattern
-func (pr *ParquetReader) FilterByGroupIter(groupPattern string) iter.Seq2[ParquetLogEntry, error] {
-	return FilterByGroupIter(pr.ReadEntriesIter(), groupPattern)
+func (pr *ParquetReader) FilterByGroupIter(ctx context.Context, groupPattern string) iter.Seq2[ParquetLogEntry, error] {
+	return FilterByGroupIter(pr.ReadEntriesIter(ctx), groupPattern)
 }
 
 // SeekToRow returns an iterator starting from the specified row number (0-based)
-func (pr *ParquetReader) SeekToRow(startRow int64) iter.Seq2[ParquetLogEntry, error] {
-	return readParquetFileFromRowIter(pr.ctx, pr.filename, startRow)
+func (pr *ParquetReader) SeekToRow(ctx context.Context, startRow int64) iter.Seq2[ParquetLogEntry, error] {
+	return readParquetFileFromRowIter(ctx, pr.filename, startRow)
 }
 
 // GetFileInfo returns metadata about the Parquet file
@@ -200,13 +197,13 @@ func (pr *ParquetReader) GetFileInfo() (*ParquetFileInfo, error) {
 }
 
 // SearchEntriesIter returns an iterator over search results with context
-func (pr *ParquetReader) SearchEntriesIter(options SearchOptions) iter.Seq2[SearchResult, error] {
-	return searchParquetFileIter(pr.ctx, pr.filename, options)
+func (pr *ParquetReader) SearchEntriesIter(ctx context.Context, options SearchOptions) iter.Seq2[SearchResult, error] {
+	return searchParquetFileIter(ctx, pr.filename, options)
 }
 
 // ReadParquetFileIter is a convenience function to get an iterator over entries from a Parquet file
 func ReadParquetFileIter(ctx context.Context, filename string) iter.Seq2[ParquetLogEntry, error] {
-	return readParquetFileIter(ctx, filename)
+	return readParquetFileStreamingIter(ctx, filename, 5000)
 }
 
 // readParquetFileIter reads a Parquet file and returns an iterator over log entries using streaming

--- a/query_bench_test.go
+++ b/query_bench_test.go
@@ -14,13 +14,13 @@ func BenchmarkParquetReader_ReadEntriesIter(b *testing.B) {
 		b.Skip("test_logs.parquet not found - run parse command first to generate test data")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	b.ReportAllocs()
 
 	for b.Loop() {
 		count := 0
-		for entry, err := range reader.ReadEntriesIter() {
+		for entry, err := range reader.ReadEntriesIter(b.Context()) {
 			if err != nil {
 				b.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -40,13 +40,13 @@ func BenchmarkParquetReader_FilterByGroupIter(b *testing.B) {
 		b.Skip("test_logs.parquet not found - run parse command first to generate test data")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	b.ReportAllocs()
 
 	for b.Loop() {
 		count := 0
-		for entry, err := range reader.FilterByGroupIter("environment") {
+		for entry, err := range reader.FilterByGroupIter(b.Context(), "environment") {
 			if err != nil {
 				b.Fatalf("FilterByGroupIter failed: %v", err)
 			}
@@ -88,7 +88,7 @@ func BenchmarkStreamingGroupAnalysis(b *testing.B) {
 		b.Skip("test_logs.parquet not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -96,7 +96,7 @@ func BenchmarkStreamingGroupAnalysis(b *testing.B) {
 	for b.Loop() {
 		groupMap := make(map[string]*GroupInfo)
 
-		for entry, err := range reader.ReadEntriesIter() {
+		for entry, err := range reader.ReadEntriesIter(b.Context()) {
 			if err != nil {
 				b.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -133,12 +133,12 @@ func BenchmarkParquetReaderOperations(b *testing.B) {
 		b.Skip("test_logs.parquet not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	b.Run("ReadEntriesIter", func(b *testing.B) {
 		for b.Loop() {
 			count := 0
-			for entry, err := range reader.ReadEntriesIter() {
+			for entry, err := range reader.ReadEntriesIter(b.Context()) {
 				if err != nil {
 					b.Fatalf("ReadEntriesIter failed: %v", err)
 				}
@@ -151,7 +151,7 @@ func BenchmarkParquetReaderOperations(b *testing.B) {
 	b.Run("FilterByGroupIter", func(b *testing.B) {
 		for b.Loop() {
 			count := 0
-			for entry, err := range reader.FilterByGroupIter("environment") {
+			for entry, err := range reader.FilterByGroupIter(b.Context(), "environment") {
 				if err != nil {
 					b.Fatalf("FilterByGroupIter failed: %v", err)
 				}
@@ -169,14 +169,14 @@ func BenchmarkStreamingMemoryUsage(b *testing.B) {
 		b.Skip("test_logs.parquet not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	b.Run("StreamingProcessing", func(b *testing.B) {
 		b.ResetTimer()
 		b.ReportAllocs()
 
 		for b.Loop() {
-			for entry, err := range reader.ReadEntriesIter() {
+			for entry, err := range reader.ReadEntriesIter(b.Context()) {
 				if err != nil {
 					b.Fatalf("ReadEntriesIter failed: %v", err)
 				}
@@ -195,7 +195,7 @@ func BenchmarkEarlyTermination(b *testing.B) {
 		b.Skip("test_logs.parquet not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 	targetCount := 100 // Only process first 100 entries
 
 	b.Run("Iterator_StopEarly", func(b *testing.B) {
@@ -204,7 +204,7 @@ func BenchmarkEarlyTermination(b *testing.B) {
 
 		for b.Loop() {
 			count := 0
-			for entry, err := range reader.ReadEntriesIter() {
+			for entry, err := range reader.ReadEntriesIter(b.Context()) {
 				if err != nil {
 					b.Fatalf("ReadEntriesIter failed: %v", err)
 				}
@@ -224,7 +224,7 @@ func BenchmarkEarlyTermination(b *testing.B) {
 
 		for b.Loop() {
 			count := 0
-			for entry, err := range reader.FilterByGroupIter("test") {
+			for entry, err := range reader.FilterByGroupIter(b.Context(), "test") {
 				if err != nil {
 					b.Fatalf("FilterByGroupIter failed: %v", err)
 				}

--- a/query_seek_test.go
+++ b/query_seek_test.go
@@ -12,7 +12,7 @@ func TestParquetReader_GetFileInfo(t *testing.T) {
 		t.Skip("test data not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	info, err := reader.GetFileInfo()
 	if err != nil {
@@ -42,7 +42,7 @@ func TestParquetReader_SeekToRow(t *testing.T) {
 		t.Skip("test data not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	// Get file info first
 	info, err := reader.GetFileInfo()
@@ -52,7 +52,7 @@ func TestParquetReader_SeekToRow(t *testing.T) {
 
 	t.Run("SeekToBeginning", func(t *testing.T) {
 		entryCount := 0
-		for entry, err := range reader.SeekToRow(0) {
+		for entry, err := range reader.SeekToRow(t.Context(), 0) {
 			if err != nil {
 				t.Fatalf("SeekToRow(0) failed: %v", err)
 			}
@@ -82,7 +82,7 @@ func TestParquetReader_SeekToRow(t *testing.T) {
 		midRow := info.RowCount / 2
 		entryCount := 0
 
-		for entry, err := range reader.SeekToRow(midRow) {
+		for entry, err := range reader.SeekToRow(t.Context(), midRow) {
 			if err != nil {
 				t.Fatalf("SeekToRow(%d) failed: %v", midRow, err)
 			}
@@ -106,7 +106,7 @@ func TestParquetReader_SeekToRow(t *testing.T) {
 
 	t.Run("SeekBeyondFile", func(t *testing.T) {
 		entryCount := 0
-		for _, err := range reader.SeekToRow(info.RowCount + 100) {
+		for _, err := range reader.SeekToRow(t.Context(), info.RowCount+100) {
 			if err == nil {
 				entryCount++
 				if entryCount > 0 {
@@ -125,7 +125,7 @@ func TestParquetReader_SeekToRow(t *testing.T) {
 		entryCount := 0
 		targetCount := 3
 
-		for _, err := range reader.SeekToRow(5) {
+		for _, err := range reader.SeekToRow(t.Context(), 5) {
 			if err != nil {
 				t.Fatalf("SeekToRow(5) failed: %v", err)
 			}

--- a/query_test.go
+++ b/query_test.go
@@ -1,7 +1,6 @@
 package buildkitelogs
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -14,7 +13,7 @@ func TestParquetReader(t *testing.T) {
 	}
 
 	t.Run("NewParquetReader", func(t *testing.T) {
-		reader := NewParquetReader(context.Background(), testFile)
+		reader := NewParquetReader(testFile)
 		if reader == nil {
 			t.Fatal("NewParquetReader returned nil")
 		}
@@ -24,11 +23,11 @@ func TestParquetReader(t *testing.T) {
 	})
 
 	t.Run("ReadEntriesIter", func(t *testing.T) {
-		reader := NewParquetReader(context.Background(), testFile)
+		reader := NewParquetReader(testFile)
 		entryCount := 0
 		var firstEntry ParquetLogEntry
 
-		for entry, err := range reader.ReadEntriesIter() {
+		for entry, err := range reader.ReadEntriesIter(t.Context()) {
 			if err != nil {
 				t.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -58,10 +57,10 @@ func TestParquetReader(t *testing.T) {
 	})
 
 	t.Run("FilterByGroupIter", func(t *testing.T) {
-		reader := NewParquetReader(context.Background(), testFile)
+		reader := NewParquetReader(testFile)
 		entryCount := 0
 
-		for entry, err := range reader.FilterByGroupIter("environment") {
+		for entry, err := range reader.FilterByGroupIter(t.Context(), "environment") {
 			if err != nil {
 				t.Fatalf("FilterByGroupIter failed: %v", err)
 			}
@@ -84,11 +83,11 @@ func TestParquetReader(t *testing.T) {
 	})
 
 	t.Run("StreamingGroupAnalysis", func(t *testing.T) {
-		reader := NewParquetReader(context.Background(), testFile)
+		reader := NewParquetReader(testFile)
 		groupMap := make(map[string]*GroupInfo)
 		totalEntries := 0
 
-		for entry, err := range reader.ReadEntriesIter() {
+		for entry, err := range reader.ReadEntriesIter(t.Context()) {
 			if err != nil {
 				t.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -141,11 +140,11 @@ func TestParquetReader(t *testing.T) {
 	})
 
 	t.Run("EarlyTermination", func(t *testing.T) {
-		reader := NewParquetReader(context.Background(), testFile)
+		reader := NewParquetReader(testFile)
 		targetCount := 5
 		actualCount := 0
 
-		for _, err := range reader.ReadEntriesIter() {
+		for _, err := range reader.ReadEntriesIter(t.Context()) {
 			if err != nil {
 				t.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -286,7 +285,7 @@ func TestReadParquetFileIter(t *testing.T) {
 	entryCount := 0
 	var firstEntry ParquetLogEntry
 
-	for entry, err := range ReadParquetFileIter(context.Background(), testFile) {
+	for entry, err := range ReadParquetFileIter(t.Context(), testFile) {
 		if err != nil {
 			t.Fatalf("ReadParquetFileIter failed: %v", err)
 		}
@@ -317,7 +316,7 @@ func TestReadParquetFileIter(t *testing.T) {
 
 func TestReadParquetFileIterNotFound(t *testing.T) {
 	entryCount := 0
-	for _, err := range ReadParquetFileIter(context.Background(), "nonexistent.parquet") {
+	for _, err := range ReadParquetFileIter(t.Context(), "nonexistent.parquet") {
 		if err != nil {
 			// Expected to get an error on the first iteration
 			return
@@ -336,12 +335,12 @@ func TestStreamingPerformance(t *testing.T) {
 		t.Skip("test data not found")
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	// Test that we can process entries without loading everything into memory
 	t.Run("MemoryEfficient", func(t *testing.T) {
 		entryCount := 0
-		for _, err := range reader.ReadEntriesIter() {
+		for _, err := range reader.ReadEntriesIter(t.Context()) {
 			if err != nil {
 				t.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -361,7 +360,7 @@ func TestStreamingPerformance(t *testing.T) {
 		targetCount := 10
 		actualCount := 0
 
-		for _, err := range reader.ReadEntriesIter() {
+		for _, err := range reader.ReadEntriesIter(t.Context()) {
 			if err != nil {
 				t.Fatalf("ReadEntriesIter failed: %v", err)
 			}
@@ -441,7 +440,7 @@ func TestReverseSearch(t *testing.T) {
 		t.Fatalf("Failed to create test parquet file: %v", err)
 	}
 
-	reader := NewParquetReader(context.Background(), testFile)
+	reader := NewParquetReader(testFile)
 
 	t.Run("ForwardSearch", func(t *testing.T) {
 		options := SearchOptions{
@@ -450,7 +449,7 @@ func TestReverseSearch(t *testing.T) {
 		}
 
 		results := []SearchResult{}
-		for result, err := range reader.SearchEntriesIter(options) {
+		for result, err := range reader.SearchEntriesIter(t.Context(), options) {
 			if err != nil {
 				t.Fatalf("Search failed: %v", err)
 			}
@@ -480,7 +479,7 @@ func TestReverseSearch(t *testing.T) {
 		}
 
 		results := []SearchResult{}
-		for result, err := range reader.SearchEntriesIter(options) {
+		for result, err := range reader.SearchEntriesIter(t.Context(), options) {
 			if err != nil {
 				t.Fatalf("Reverse search failed: %v", err)
 			}
@@ -511,7 +510,7 @@ func TestReverseSearch(t *testing.T) {
 		}
 
 		results := []SearchResult{}
-		for result, err := range reader.SearchEntriesIter(options) {
+		for result, err := range reader.SearchEntriesIter(t.Context(), options) {
 			if err != nil {
 				t.Fatalf("Reverse search with seek failed: %v", err)
 			}
@@ -547,7 +546,7 @@ func TestReverseSearch(t *testing.T) {
 		}
 
 		results := []SearchResult{}
-		for result, err := range reader.SearchEntriesIter(options) {
+		for result, err := range reader.SearchEntriesIter(t.Context(), options) {
 			if err != nil {
 				t.Fatalf("Reverse search with context failed: %v", err)
 			}

--- a/streaming_bench_test.go
+++ b/streaming_bench_test.go
@@ -1,7 +1,6 @@
 package buildkitelogs
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -25,12 +24,12 @@ func TestRealWorldStreamingPerformance(t *testing.T) {
 				t.Skipf("Test file %s not found", tf.path)
 			}
 
-			reader := NewParquetReader(context.Background(), tf.path)
+			reader := NewParquetReader(tf.path)
 
 			// Test streaming iterator performance
 			start := time.Now()
 			iterCount := 0
-			for entry, err := range reader.ReadEntriesIter() {
+			for entry, err := range reader.ReadEntriesIter(t.Context()) {
 				if err != nil {
 					t.Fatalf("ReadEntriesIter failed: %v", err)
 				}
@@ -42,7 +41,7 @@ func TestRealWorldStreamingPerformance(t *testing.T) {
 			// Test early termination performance
 			start = time.Now()
 			earlyCount := 0
-			for entry, err := range reader.ReadEntriesIter() {
+			for entry, err := range reader.ReadEntriesIter(t.Context()) {
 				if err != nil {
 					t.Fatalf("ReadEntriesIter failed: %v", err)
 				}
@@ -79,7 +78,7 @@ func BenchmarkStreamingFiles(b *testing.B) {
 			b.Skipf("Test file %s not found", tf.path)
 		}
 
-		reader := NewParquetReader(context.Background(), tf.path)
+		reader := NewParquetReader(tf.path)
 
 		b.Run(fmt.Sprintf("%s_StreamingFull", tf.name), func(b *testing.B) {
 			b.ResetTimer()
@@ -87,7 +86,7 @@ func BenchmarkStreamingFiles(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				count := 0
-				for entry, err := range reader.ReadEntriesIter() {
+				for entry, err := range reader.ReadEntriesIter(b.Context()) {
 					if err != nil {
 						b.Fatalf("ReadEntriesIter failed: %v", err)
 					}
@@ -103,7 +102,7 @@ func BenchmarkStreamingFiles(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				groupMap := make(map[string]*GroupInfo)
-				for entry, err := range reader.ReadEntriesIter() {
+				for entry, err := range reader.ReadEntriesIter(b.Context()) {
 					if err != nil {
 						b.Fatalf("ReadEntriesIter failed: %v", err)
 					}
@@ -136,7 +135,7 @@ func BenchmarkStreamingFiles(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				count := 0
-				for entry, err := range reader.ReadEntriesIter() {
+				for entry, err := range reader.ReadEntriesIter(b.Context()) {
 					if err != nil {
 						b.Fatalf("ReadEntriesIter failed: %v", err)
 					}
@@ -156,7 +155,7 @@ func BenchmarkStreamingFiles(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				count := 0
-				for entry, err := range reader.FilterByGroupIter("test") {
+				for entry, err := range reader.FilterByGroupIter(b.Context(), "test") {
 					if err != nil {
 						b.Fatalf("FilterByGroupIter failed: %v", err)
 					}


### PR DESCRIPTION
Remove the ctx field from ParquetReader and instead accept context.Context as a parameter on ReadEntriesIter, FilterByGroupIter, SeekToRow, and runStreamingQuery. This follows Go conventions for context propagation.

Reduced `batchSize = 1000` to reduce memory usage when log lines are "endless" streams of status changes... 