### PR TITLE
feat(scope): add org-scoped job log access

### DIFF
--- a/client.go
+++ b/client.go
@@ -169,7 +169,34 @@ func NewClientWithAPI(ctx context.Context, api BuildkiteAPI, storageURL string, 
 //   - ttl: Time-to-live for cache (use 0 for default 30s)
 //   - forceRefresh: If true, forces re-download even if cache exists
 func (c *Client) NewReader(ctx context.Context, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (*ParquetReader, error) {
-	filePath, err := c.downloadAndCache(ctx, org, pipeline, build, job, ttl, forceRefresh)
+	filePath, err := c.downloadAndCache(ctx, c.api, org, pipeline, build, job, ttl, forceRefresh)
+	if err != nil {
+		return nil, err
+	}
+
+	return newParquetReaderOwned(filePath), nil
+}
+
+// NewReaderByJobID downloads and caches job logs using only an organization slug and job UUID.
+// Pipeline and build identifiers are resolved from the job's build_url so cache keys remain
+// compatible with pipeline-scoped readers.
+func (c *Client) NewReaderByJobID(ctx context.Context, org, job string, ttl time.Duration, forceRefresh bool) (*ParquetReader, error) {
+	scoped, ok := c.api.(OrgScopedJobAPI)
+	if !ok {
+		return nil, fmt.Errorf("API client does not support organization-scoped job access")
+	}
+
+	location, err := ResolveJobLocation(ctx, scoped, org, job)
+	if err != nil {
+		return nil, err
+	}
+
+	adapter := &orgJobReaderAPI{
+		base:     scoped,
+		location: location,
+	}
+
+	filePath, err := c.downloadAndCache(ctx, adapter, location.Org, location.Pipeline, location.Build, location.Job, ttl, forceRefresh)
 	if err != nil {
 		return nil, err
 	}
@@ -179,12 +206,12 @@ func (c *Client) NewReader(ctx context.Context, org, pipeline, build, job string
 
 // downloadAndCache downloads and caches job logs as Parquet format, returning the local file path.
 // Callers are responsible for removing the returned temp file.
-func (c *Client) downloadAndCache(ctx context.Context, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (string, error) {
+func (c *Client) downloadAndCache(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (string, error) {
 	if err := ValidateAPIParams(org, pipeline, build, job); err != nil {
 		return "", err
 	}
 
-	return c.downloadAndCacheWithBlobStorage(ctx, org, pipeline, build, job, ttl, forceRefresh)
+	return c.downloadAndCacheWithBlobStorage(ctx, api, org, pipeline, build, job, ttl, forceRefresh)
 }
 
 // Hooks returns the hooks instance for registering callback functions
@@ -193,7 +220,7 @@ func (c *Client) Hooks() *Hooks {
 }
 
 // downloadAndCacheWithBlobStorage downloads logs using the client's blob storage backend
-func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (string, error) {
+func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string, ttl time.Duration, forceRefresh bool) (string, error) {
 	if ttl == 0 {
 		ttl = 30 * time.Second // Default TTL
 	}
@@ -226,7 +253,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Get job status to determine caching strategy
 	jobStatusStart := time.Now()
-	jobStatus, err := c.api.GetJobStatus(ctx, org, pipeline, build, job)
+	jobStatus, err := api.GetJobStatus(ctx, org, pipeline, build, job)
 	if err != nil {
 		return "", fmt.Errorf("failed to get job status: %w", err)
 	}
@@ -266,7 +293,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, org, pipel
 
 	// Download fresh logs from API
 	logDownloadStart := time.Now()
-	logReader, err := c.api.GetJobLog(ctx, org, pipeline, build, job)
+	logReader, err := api.GetJobLog(ctx, org, pipeline, build, job)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch logs from API: %w", err)
 	}

--- a/examples/high-level-client/README.md
+++ b/examples/high-level-client/README.md
@@ -19,6 +19,14 @@ The `Client` provides a simplified interface for common operations:
 export BUILDKITE_API_TOKEN="your-buildkite-api-token"
 ```
 
+Optional overrides for the example job (defaults are placeholders):
+```bash
+export BUILDKITE_ORGANIZATION_SLUG="myorg"
+export BUILDKITE_PIPELINE_SLUG="mypipeline"
+export BUILDKITE_BUILD_NUMBER="123"
+export BUILDKITE_JOB_ID="your-job-uuid"
+```
+
 ## Running the Example
 
 ```bash
@@ -28,9 +36,9 @@ go run main.go
 
 ## What the Example Does
 
-The example demonstrates three main use cases plus hooks for observability:
+The example demonstrates two main use cases plus hooks for observability:
 
-### 1. Basic Usage with Official Client
+### 1. Pipeline-Scoped Reader (`NewReader`)
 
 Creates a `Client` using the official `*buildkite.Client` and shows how to:
 - Download and cache logs to a local file
@@ -38,21 +46,18 @@ Creates a `Client` using the official `*buildkite.Client` and shows how to:
 - Read basic file information (row count, file size, etc.)
 - Iterate through log entries
 
-### 2. Advanced Querying
+Requires organization, pipeline, build, and job identifiers.
 
-Shows how to use the `ParquetReader` for advanced operations:
-- Search for specific patterns in logs with context
-- Filter entries by group/section
-- Get file metadata and statistics
+### 2. Job UUID-Only Reader (`NewReaderByJobID`)
 
-### 3. Custom API Implementation
+Shows how to fetch and query logs when you only have an organization slug and job UUID:
+- Uses organization-scoped REST endpoints (`/v2/organizations/{org}/jobs/{jobID}`)
+- Resolves pipeline and build from the job's `build_url` for cache key compatibility
+- Searches log entries with regex patterns
 
-Demonstrates how to use a custom `BuildkiteAPI` implementation instead of the official client, which is useful for:
-- Testing with mock data
-- Custom authentication or rate limiting
-- Integrating with other log sources
+This matches how the Buildkite CLI accesses job logs by UUID alone.
 
-### 4. Observability Hooks
+### 3. Observability Hooks
 
 Shows how to set up hooks for detailed observability of the download and caching process:
 - Cache check timing and results
@@ -95,9 +100,14 @@ Creates a client using a custom API implementation.
 
 Downloads and caches logs, returns the local file path.
 
-### `NewReader(ctx, org, pipeline, build, job, ttl, forceRefresh)`
+### `NewReaderByJobID(ctx, org, job, ttl, forceRefresh)`
 
-Downloads/caches logs and returns a `ParquetReader` for querying.
+Downloads/caches logs using only org + job UUID and returns a `ParquetReader`.
+Pipeline and build are resolved automatically from the job's `build_url`.
+
+### `ResolveJobLocation(ctx, api, org, job)`
+
+Resolves pipeline and build identifiers for a job UUID without downloading logs.
 
 ## Error Handling
 

--- a/examples/high-level-client/main.go
+++ b/examples/high-level-client/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"time"
@@ -13,29 +12,31 @@ import (
 )
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	ctx := context.Background()
 
-	// Get API token from environment
 	apiToken := os.Getenv("BUILDKITE_API_TOKEN")
 	if apiToken == "" {
-		log.Fatal("BUILDKITE_API_TOKEN environment variable is required")
+		return fmt.Errorf("BUILDKITE_API_TOKEN environment variable is required")
 	}
 
-	// Create buildkite client
 	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(apiToken))
 	if err != nil {
-		log.Fatal("Failed to create buildkite client:", err)
+		return fmt.Errorf("failed to create buildkite client: %w", err)
 	}
 
-	// Create high-level Client
-	storageURL := "file://~/.bklog" // Uses default storage location
+	storageURL := "file://~/.bklog"
 	buildkiteLogsClient, err := buildkitelogs.NewClient(ctx, client, storageURL)
 	if err != nil {
-		log.Fatal("Failed to create buildkite logs client:", err)
+		return fmt.Errorf("failed to create buildkite logs client: %w", err)
 	}
 	defer buildkiteLogsClient.Close()
 
-	// Setup hooks for observability
 	buildkiteLogsClient.Hooks().AddAfterCacheCheck(func(ctx context.Context, result *buildkitelogs.CacheCheckResult) {
 		log.Printf("Cache check for %s: exists=%t, took %v", result.BlobKey, result.Exists, result.Duration)
 	})
@@ -49,48 +50,29 @@ func main() {
 		log.Printf("Downloaded %d bytes in %v", result.LogSize, result.Duration)
 	})
 
-	buildkiteLogsClient.Hooks().AddAfterLogParsing(func(ctx context.Context, result *buildkitelogs.LogParsingResult) {
-		log.Printf("Parsed logs to %d bytes Parquet in %v", result.ParquetSize, result.Duration)
-	})
+	org := envOrDefault("BUILDKITE_ORGANIZATION_SLUG", "myorg")
+	pipeline := envOrDefault("BUILDKITE_PIPELINE_SLUG", "mypipeline")
+	build := envOrDefault("BUILDKITE_BUILD_NUMBER", "123")
+	job := envOrDefault("BUILDKITE_JOB_ID", "abc-123-def")
 
-	buildkiteLogsClient.Hooks().AddAfterBlobStorage(func(ctx context.Context, result *buildkitelogs.BlobStorageResult) {
-		log.Printf("Stored %d bytes to blob storage (terminal: %t) in %v",
-			result.DataSize, result.IsTerminal, result.Duration)
-	})
-
-	buildkiteLogsClient.Hooks().AddAfterLocalCache(func(ctx context.Context, result *buildkitelogs.LocalCacheResult) {
-		log.Printf("Created local cache file %s (%d bytes) in %v",
-			result.LocalPath, result.FileSize, result.Duration)
-	})
-
-	org := "myorg"
-	pipeline := "mypipeline"
-	build := "123"
-	job := "abc-123-def"
-
-	// Example 1: Get a reader and query the logs
-	fmt.Println("Creating reader and querying logs...")
-	reader, err := buildkiteLogsClient.NewReader(ctx, org, pipeline, build, job, time.Minute*5, false)
+	// Example 1: pipeline-scoped reader (org + pipeline + build + job)
+	fmt.Println("Example 1: NewReader with pipeline and build context...")
+	reader, err := buildkiteLogsClient.NewReader(ctx, org, pipeline, build, job, 5*time.Minute, false)
 	if err != nil {
-		log.Printf("Failed to create reader: %v", err)
-		return
+		return fmt.Errorf("failed to create reader: %w", err)
 	}
 	defer reader.Close()
 
-	// Get file info
 	info, err := reader.GetFileInfo()
 	if err != nil {
-		log.Printf("Failed to get file info: %v", err)
-		return
+		return fmt.Errorf("failed to get file info: %w", err)
 	}
 	fmt.Printf("Log file contains %d rows\n", info.RowCount)
 
-	// Read first 10 entries
 	count := 0
 	for entry, err := range reader.ReadEntriesIter(ctx) {
 		if err != nil {
-			log.Printf("Error reading entries: %v", err)
-			return
+			return fmt.Errorf("error reading entries: %w", err)
 		}
 
 		fmt.Printf("Entry %d: %s\n", count+1, entry.Content)
@@ -100,24 +82,22 @@ func main() {
 		}
 	}
 
-	// Example 2: Using with custom API implementation
-	fmt.Println("\nExample with custom API:")
-	customAPI := &CustomBuildkiteAPI{} // Your custom implementation
-	customClient, err := buildkitelogs.NewClientWithAPI(ctx, customAPI, storageURL)
+	// Example 2: org-scoped reader (org + job UUID only)
+	// Uses GET /v2/organizations/{org}/jobs/{jobID} and .../log under the hood.
+	// Pipeline and build are resolved from build_url so cache keys match Example 1.
+	fmt.Println("\nExample 2: NewReaderByJobID with org and job UUID only...")
+	location, err := buildkitelogs.ResolveJobLocation(ctx, buildkitelogs.NewBuildkiteAPIExistingClient(client), org, job)
 	if err != nil {
-		log.Printf("Failed to create custom client: %v", err)
-		return
+		return fmt.Errorf("failed to resolve job location: %w", err)
 	}
-	defer customClient.Close()
+	fmt.Printf("Resolved pipeline=%s build=%s for job %s\n", location.Pipeline, location.Build, location.Job)
 
-	reader2, err := customClient.NewReader(ctx, org, pipeline, build, job, time.Minute*5, false)
+	readerByJob, err := buildkiteLogsClient.NewReaderByJobID(ctx, org, job, 5*time.Minute, false)
 	if err != nil {
-		log.Printf("Failed to create reader with custom API: %v", err)
-		return
+		return fmt.Errorf("failed to create reader by job ID: %w", err)
 	}
-	defer reader2.Close()
+	defer readerByJob.Close()
 
-	// Search for specific patterns
 	searchOpts := buildkitelogs.SearchOptions{
 		Pattern:       "error",
 		Context:       2,
@@ -125,27 +105,25 @@ func main() {
 	}
 
 	fmt.Println("Searching for 'error' in logs:")
-	for result, err := range reader2.SearchEntriesIter(ctx, searchOpts) {
+	found := false
+	for result, err := range readerByJob.SearchEntriesIter(ctx, searchOpts) {
 		if err != nil {
-			log.Printf("Error searching: %v", err)
-			return
+			return fmt.Errorf("error searching: %w", err)
 		}
 		fmt.Printf("Found error at row %d: %s\n", result.Match.RowNumber, result.Match.Content)
-		break // Just show first result
+		found = true
+		break
 	}
+	if !found {
+		fmt.Println("No matches found")
+	}
+
+	return nil
 }
 
-// CustomBuildkiteAPI is an example custom implementation
-type CustomBuildkiteAPI struct {
-	// Your custom implementation fields
-}
-
-func (c *CustomBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
-	// Your custom log fetching logic
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (c *CustomBuildkiteAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*buildkitelogs.JobStatus, error) {
-	// Your custom job status logic
-	return nil, fmt.Errorf("not implemented")
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/memleak_test.go
+++ b/memleak_test.go
@@ -91,7 +91,7 @@ func TestClient_HeapStable(t *testing.T) {
 	// Warm up: run a few iterations before measuring so one-time init costs
 	// don't skew the baseline.
 	for range 3 {
-		path, err := client.downloadAndCache(ctx, "org", "pipeline", "123", "job-1", time.Minute, true)
+		path, err := client.downloadAndCache(ctx, client.api, "org", "pipeline", "123", "job-1", time.Minute, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,7 +105,7 @@ func TestClient_HeapStable(t *testing.T) {
 	runtime.ReadMemStats(&before)
 
 	for i := range iterations {
-		path, err := client.downloadAndCache(ctx, "org", "pipeline", fmt.Sprintf("%d", i), "job-1", time.Minute, true)
+		path, err := client.downloadAndCache(ctx, client.api, "org", "pipeline", fmt.Sprintf("%d", i), "job-1", time.Minute, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -144,7 +144,7 @@ func TestClient_NoTempFileAccumulation(t *testing.T) {
 
 	returnedPaths := make(map[string]bool, iterations)
 	for i := range iterations {
-		path, err := client.downloadAndCache(ctx, "org", "pipeline", fmt.Sprintf("%d", i), "job-1", time.Minute, true)
+		path, err := client.downloadAndCache(ctx, client.api, "org", "pipeline", fmt.Sprintf("%d", i), "job-1", time.Minute, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/org_scoped_api.go
+++ b/org_scoped_api.go
@@ -1,0 +1,206 @@
+package buildkitelogs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"strings"
+
+	buildkite "github.com/buildkite/go-buildkite/v5"
+)
+
+// OrgScopedJobAPI provides job access using only an organization slug and job UUID.
+// This matches the organization-scoped REST endpoints documented at
+// https://buildkite.com/docs/apis/rest-api/jobs
+type OrgScopedJobAPI interface {
+	GetJobByOrg(ctx context.Context, org, jobID string) (buildkite.Job, error)
+	GetJobLogByOrg(ctx context.Context, org, jobID string) (io.ReadCloser, error)
+}
+
+// JobLocation holds the identifiers needed for cache keys and pipeline-scoped API calls.
+type JobLocation struct {
+	Org      string
+	Pipeline string
+	Build    string
+	Job      string
+}
+
+type jobByOrgResponse struct {
+	buildkite.Job
+	BuildURL string `json:"build_url"`
+}
+
+func organizationJobPath(organization, jobID, action string) string {
+	base := fmt.Sprintf(
+		"v2/organizations/%s/jobs/%s",
+		url.PathEscape(organization),
+		url.PathEscape(jobID),
+	)
+	if action == "" {
+		return base
+	}
+	return base + "/" + action
+}
+
+func (c *BuildkiteAPIClient) getJobByOrgResponse(ctx context.Context, org, jobID string) (jobByOrgResponse, error) {
+	req, err := c.client.NewRequest(ctx, "GET", organizationJobPath(org, jobID, ""), nil)
+	if err != nil {
+		return jobByOrgResponse{}, err
+	}
+
+	var job jobByOrgResponse
+	if _, err := c.client.Do(req, &job); err != nil {
+		return jobByOrgResponse{}, fmt.Errorf("failed to get job: %w", err)
+	}
+
+	return job, nil
+}
+
+// GetJobByOrg fetches a job using the organization-scoped REST endpoint.
+func (c *BuildkiteAPIClient) GetJobByOrg(ctx context.Context, org, jobID string) (buildkite.Job, error) {
+	job, err := c.getJobByOrgResponse(ctx, org, jobID)
+	if err != nil {
+		return buildkite.Job{}, err
+	}
+	return job.Job, nil
+}
+
+// GetJobLogByOrg fetches a job log using the organization-scoped REST endpoint.
+func (c *BuildkiteAPIClient) GetJobLogByOrg(ctx context.Context, org, jobID string) (io.ReadCloser, error) {
+	req, err := c.client.NewRequest(ctx, "GET", organizationJobPath(org, jobID, "log"), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	var jobLog buildkite.JobLog
+	if _, err := c.client.Do(req, &jobLog); err != nil {
+		return nil, fmt.Errorf("failed to get job log: %w", err)
+	}
+
+	return io.NopCloser(strings.NewReader(jobLog.Content)), nil
+}
+
+// ResolveJobLocation fetches a job by organization and UUID, then resolves pipeline
+// and build identifiers from the job's build_url for cache key compatibility.
+func ResolveJobLocation(ctx context.Context, api OrgScopedJobAPI, org, jobID string) (JobLocation, error) {
+	if err := ValidateOrgJobParams(org, jobID); err != nil {
+		return JobLocation{}, err
+	}
+
+	var buildURL string
+	if client, ok := api.(*BuildkiteAPIClient); ok {
+		jobResp, err := client.getJobByOrgResponse(ctx, org, jobID)
+		if err != nil {
+			return JobLocation{}, err
+		}
+		buildURL = jobResp.BuildURL
+	} else {
+		job, err := api.GetJobByOrg(ctx, org, jobID)
+		if err != nil {
+			return JobLocation{}, err
+		}
+		_ = job
+		return JobLocation{}, fmt.Errorf("ResolveJobLocation requires *BuildkiteAPIClient for build_url resolution")
+	}
+
+	pipeline, build, err := parseBuildURL(buildURL)
+	if err != nil {
+		return JobLocation{}, fmt.Errorf("failed to resolve pipeline and build for job %s: %w", jobID, err)
+	}
+
+	return JobLocation{
+		Org:      org,
+		Pipeline: pipeline,
+		Build:    build,
+		Job:      jobID,
+	}, nil
+}
+
+// parseBuildURL extracts pipeline slug and build number/UUID from a Buildkite build_url.
+// Example: https://api.buildkite.com/v2/organizations/acme/pipelines/my-pipeline/builds/123
+func parseBuildURL(buildURL string) (pipeline, build string, err error) {
+	if buildURL == "" {
+		return "", "", fmt.Errorf("build_url is empty")
+	}
+
+	parsed, err := url.Parse(buildURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid build_url: %w", err)
+	}
+
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	// organizations/{org}/pipelines/{pipeline}/builds/{build}
+	for i := 0; i+3 < len(segments); i++ {
+		if segments[i] == "pipelines" && i+2 < len(segments) && segments[i+2] == "builds" {
+			pipeline = segments[i+1]
+			build = path.Base(strings.Join(segments[i+3:], "/"))
+			if pipeline != "" && build != "" {
+				return pipeline, build, nil
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("could not parse pipeline and build from build_url %q", buildURL)
+}
+
+// ValidateOrgJobParams validates organization and job UUID parameters.
+func ValidateOrgJobParams(org, job string) error {
+	var missing []string
+
+	if org == "" {
+		missing = append(missing, "organization")
+	}
+	if job == "" {
+		missing = append(missing, "job")
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required API parameters: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+// jobStatusFromJob converts a Buildkite job model to JobStatus.
+func jobStatusFromJob(job buildkite.Job) *JobStatus {
+	state := JobState(job.State)
+	status := &JobStatus{
+		ID:         job.ID,
+		State:      state,
+		IsTerminal: IsTerminalState(state),
+		WebURL:     job.WebURL,
+	}
+
+	if job.ExitStatus != nil {
+		status.ExitStatus = job.ExitStatus
+	}
+
+	if job.FinishedAt != nil {
+		finishedAt := job.FinishedAt.Time
+		status.FinishedAt = &finishedAt
+	}
+
+	return status
+}
+
+// orgJobReaderAPI adapts OrgScopedJobAPI for the pipeline-scoped BuildkiteAPI interface
+// while preserving org-only fetch semantics and resolved cache identifiers.
+type orgJobReaderAPI struct {
+	base     OrgScopedJobAPI
+	location JobLocation
+}
+
+func (a *orgJobReaderAPI) GetJobLog(ctx context.Context, _, _, _, _ string) (io.ReadCloser, error) {
+	return a.base.GetJobLogByOrg(ctx, a.location.Org, a.location.Job)
+}
+
+func (a *orgJobReaderAPI) GetJobStatus(ctx context.Context, _, _, _, _ string) (*JobStatus, error) {
+	job, err := a.base.GetJobByOrg(ctx, a.location.Org, a.location.Job)
+	if err != nil {
+		return nil, err
+	}
+	return jobStatusFromJob(job), nil
+}

--- a/org_scoped_api.go
+++ b/org_scoped_api.go
@@ -13,10 +13,12 @@ import (
 
 // OrgScopedJobAPI provides job access using only an organization slug and job UUID.
 // This matches the organization-scoped REST endpoints documented at
-// https://buildkite.com/docs/apis/rest-api/jobs
+// https://buildkite.com/docs/apis/rest-api/jobs. Implementations must also resolve
+// pipeline/build identifiers so org-scoped readers can use compatible cache keys.
 type OrgScopedJobAPI interface {
 	GetJobByOrg(ctx context.Context, org, jobID string) (buildkite.Job, error)
 	GetJobLogByOrg(ctx context.Context, org, jobID string) (io.ReadCloser, error)
+	GetJobLocationByOrg(ctx context.Context, org, jobID string) (JobLocation, error)
 }
 
 // JobLocation holds the identifiers needed for cache keys and pipeline-scoped API calls.
@@ -83,30 +85,19 @@ func (c *BuildkiteAPIClient) GetJobLogByOrg(ctx context.Context, org, jobID stri
 	return io.NopCloser(strings.NewReader(jobLog.Content)), nil
 }
 
-// ResolveJobLocation fetches a job by organization and UUID, then resolves pipeline
+// GetJobLocationByOrg fetches a job by organization and UUID, then resolves pipeline
 // and build identifiers from the job's build_url for cache key compatibility.
-func ResolveJobLocation(ctx context.Context, api OrgScopedJobAPI, org, jobID string) (JobLocation, error) {
+func (c *BuildkiteAPIClient) GetJobLocationByOrg(ctx context.Context, org, jobID string) (JobLocation, error) {
 	if err := ValidateOrgJobParams(org, jobID); err != nil {
 		return JobLocation{}, err
 	}
 
-	var buildURL string
-	if client, ok := api.(*BuildkiteAPIClient); ok {
-		jobResp, err := client.getJobByOrgResponse(ctx, org, jobID)
-		if err != nil {
-			return JobLocation{}, err
-		}
-		buildURL = jobResp.BuildURL
-	} else {
-		job, err := api.GetJobByOrg(ctx, org, jobID)
-		if err != nil {
-			return JobLocation{}, err
-		}
-		_ = job
-		return JobLocation{}, fmt.Errorf("ResolveJobLocation requires *BuildkiteAPIClient for build_url resolution")
+	jobResp, err := c.getJobByOrgResponse(ctx, org, jobID)
+	if err != nil {
+		return JobLocation{}, err
 	}
 
-	pipeline, build, err := parseBuildURL(buildURL)
+	pipeline, build, err := parseBuildURL(jobResp.BuildURL)
 	if err != nil {
 		return JobLocation{}, fmt.Errorf("failed to resolve pipeline and build for job %s: %w", jobID, err)
 	}
@@ -117,6 +108,14 @@ func ResolveJobLocation(ctx context.Context, api OrgScopedJobAPI, org, jobID str
 		Build:    build,
 		Job:      jobID,
 	}, nil
+}
+
+// ResolveJobLocation resolves the cache identifiers for an organization-scoped job.
+func ResolveJobLocation(ctx context.Context, api OrgScopedJobAPI, org, jobID string) (JobLocation, error) {
+	if err := ValidateOrgJobParams(org, jobID); err != nil {
+		return JobLocation{}, err
+	}
+	return api.GetJobLocationByOrg(ctx, org, jobID)
 }
 
 // parseBuildURL extracts pipeline slug and build number/UUID from a Buildkite build_url.

--- a/org_scoped_api_test.go
+++ b/org_scoped_api_test.go
@@ -3,6 +3,7 @@ package buildkitelogs
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -188,6 +189,66 @@ func TestOrgScopedJobAPI(t *testing.T) {
 			t.Error("expected non-zero row count")
 		}
 	})
+}
+
+type customOrgScopedAPI struct {
+	location JobLocation
+	job      buildkite.Job
+	log      string
+}
+
+func (a *customOrgScopedAPI) GetJobByOrg(ctx context.Context, org, jobID string) (buildkite.Job, error) {
+	return a.job, nil
+}
+
+func (a *customOrgScopedAPI) GetJobLogByOrg(ctx context.Context, org, jobID string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(a.log)), nil
+}
+
+func (a *customOrgScopedAPI) GetJobLocationByOrg(ctx context.Context, org, jobID string) (JobLocation, error) {
+	return a.location, nil
+}
+
+func (a *customOrgScopedAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(a.log)), nil
+}
+
+func (a *customOrgScopedAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error) {
+	return jobStatusFromJob(a.job), nil
+}
+
+func TestNewReaderByJobIDSupportsCustomOrgScopedAPI(t *testing.T) {
+	const (
+		org        = "buildkite"
+		jobID      = "0190046e-e199-453b-a302-a21a4d649d31"
+		logContent = "\x1b_bk;t=1745322209921\x07custom api log line\n"
+	)
+
+	api := &customOrgScopedAPI{
+		location: JobLocation{Org: org, Pipeline: "starter-pipeline", Build: "76", Job: jobID},
+		job:      buildkite.Job{ID: jobID, State: "passed"},
+		log:      logContent,
+	}
+
+	client, err := NewClientWithAPI(context.Background(), api, "file://"+t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClientWithAPI: %v", err)
+	}
+	defer client.Close()
+
+	reader, err := client.NewReaderByJobID(context.Background(), org, jobID, 0, false)
+	if err != nil {
+		t.Fatalf("NewReaderByJobID: %v", err)
+	}
+	defer reader.Close()
+
+	info, err := reader.GetFileInfo()
+	if err != nil {
+		t.Fatalf("GetFileInfo: %v", err)
+	}
+	if info.RowCount == 0 {
+		t.Error("expected non-zero row count")
+	}
 }
 
 func TestGetJobLogByOrgUsesOrganizationEndpoint(t *testing.T) {

--- a/org_scoped_api_test.go
+++ b/org_scoped_api_test.go
@@ -1,0 +1,219 @@
+package buildkitelogs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+func TestParseBuildURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		buildURL     string
+		wantPipeline string
+		wantBuild    string
+		expectError  bool
+	}{
+		{
+			name:         "standard api url",
+			buildURL:     "https://api.buildkite.com/v2/organizations/acme/pipelines/my-pipeline/builds/123",
+			wantPipeline: "my-pipeline",
+			wantBuild:    "123",
+		},
+		{
+			name:         "build uuid",
+			buildURL:     "https://api.buildkite.com/v2/organizations/acme/pipelines/deploy/builds/0190046e-e199-453b-a302-a21a4d649d31",
+			wantPipeline: "deploy",
+			wantBuild:    "0190046e-e199-453b-a302-a21a4d649d31",
+		},
+		{
+			name:        "empty url",
+			buildURL:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid url",
+			buildURL:    "https://example.com/not-a-build-url",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline, build, err := parseBuildURL(tt.buildURL)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBuildURL() error = %v", err)
+			}
+			if pipeline != tt.wantPipeline {
+				t.Errorf("pipeline = %q, want %q", pipeline, tt.wantPipeline)
+			}
+			if build != tt.wantBuild {
+				t.Errorf("build = %q, want %q", build, tt.wantBuild)
+			}
+		})
+	}
+}
+
+func TestValidateOrgJobParams(t *testing.T) {
+	if err := ValidateOrgJobParams("org", "job"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ValidateOrgJobParams("", "job"); err == nil {
+		t.Fatal("expected error for missing org")
+	}
+	if err := ValidateOrgJobParams("org", ""); err == nil {
+		t.Fatal("expected error for missing job")
+	}
+}
+
+func TestOrgScopedJobAPI(t *testing.T) {
+	const (
+		org        = "buildkite"
+		jobID      = "0190046e-e199-453b-a302-a21a4d649d31"
+		pipeline   = "starter-pipeline"
+		build      = "76"
+		logContent = "\x1b_bk;t=1745322209921\x07Build failed: compile error\n"
+	)
+
+	jobResponse := buildkite.Job{
+		ID:     jobID,
+		State:  "failed",
+		WebURL: "https://buildkite.com/buildkite/starter-pipeline/builds/76",
+	}
+	jobResponseWithURL := struct {
+		buildkite.Job
+		BuildURL string `json:"build_url"`
+	}{
+		Job:      jobResponse,
+		BuildURL: "https://api.buildkite.com/v2/organizations/buildkite/pipelines/starter-pipeline/builds/76",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/log"):
+			_ = json.NewEncoder(w).Encode(buildkite.JobLog{Content: logContent})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/jobs/"):
+			_ = json.NewEncoder(w).Encode(jobResponseWithURL)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	bkClient, err := buildkite.NewOpts(
+		buildkite.WithBaseURL(server.URL),
+		buildkite.WithTokenAuth("test-token"),
+	)
+	if err != nil {
+		t.Fatalf("NewOpts: %v", err)
+	}
+
+	apiClient := NewBuildkiteAPIExistingClient(bkClient)
+	ctx := context.Background()
+
+	t.Run("GetJobByOrg", func(t *testing.T) {
+		job, err := apiClient.GetJobByOrg(ctx, org, jobID)
+		if err != nil {
+			t.Fatalf("GetJobByOrg: %v", err)
+		}
+		if job.ID != jobID {
+			t.Errorf("ID = %q, want %q", job.ID, jobID)
+		}
+	})
+
+	t.Run("GetJobLogByOrg", func(t *testing.T) {
+		reader, err := apiClient.GetJobLogByOrg(ctx, org, jobID)
+		if err != nil {
+			t.Fatalf("GetJobLogByOrg: %v", err)
+		}
+		defer reader.Close()
+
+		buf := make([]byte, len(logContent))
+		n, err := reader.Read(buf)
+		if err != nil {
+			t.Fatalf("Read: %v", err)
+		}
+		if string(buf[:n]) != logContent {
+			t.Errorf("log content = %q, want %q", string(buf[:n]), logContent)
+		}
+	})
+
+	t.Run("ResolveJobLocation", func(t *testing.T) {
+		location, err := ResolveJobLocation(ctx, apiClient, org, jobID)
+		if err != nil {
+			t.Fatalf("ResolveJobLocation: %v", err)
+		}
+		if location.Pipeline != pipeline {
+			t.Errorf("Pipeline = %q, want %q", location.Pipeline, pipeline)
+		}
+		if location.Build != build {
+			t.Errorf("Build = %q, want %q", location.Build, build)
+		}
+		if location.Job != jobID {
+			t.Errorf("Job = %q, want %q", location.Job, jobID)
+		}
+	})
+
+	t.Run("NewReaderByJobID", func(t *testing.T) {
+		tempDir := t.TempDir()
+		client, err := NewClientWithAPI(ctx, apiClient, "file://"+tempDir)
+		if err != nil {
+			t.Fatalf("NewClientWithAPI: %v", err)
+		}
+		defer client.Close()
+
+		reader, err := client.NewReaderByJobID(ctx, org, jobID, 0, false)
+		if err != nil {
+			t.Fatalf("NewReaderByJobID: %v", err)
+		}
+		defer reader.Close()
+
+		info, err := reader.GetFileInfo()
+		if err != nil {
+			t.Fatalf("GetFileInfo: %v", err)
+		}
+		if info.RowCount == 0 {
+			t.Error("expected non-zero row count")
+		}
+	})
+}
+
+func TestGetJobLogByOrgUsesOrganizationEndpoint(t *testing.T) {
+	const jobID = "0190046e-e199-453b-a302-a21a4d649d31"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/organizations/buildkite/jobs/"+jobID+"/log" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(buildkite.JobLog{Content: "log data"})
+	}))
+	defer server.Close()
+
+	bkClient, err := buildkite.NewOpts(
+		buildkite.WithBaseURL(server.URL),
+		buildkite.WithTokenAuth("test-token"),
+	)
+	if err != nil {
+		t.Fatalf("NewOpts: %v", err)
+	}
+
+	apiClient := NewBuildkiteAPIExistingClient(bkClient)
+	reader, err := apiClient.GetJobLogByOrg(context.Background(), "buildkite", jobID)
+	if err != nil {
+		t.Fatalf("GetJobLogByOrg: %v", err)
+	}
+	defer reader.Close()
+}


### PR DESCRIPTION
### Description

Adds organization-scoped job log access to buildkite-logs, so callers can work with only an org slug and job UUID — matching the CLI’s GET /v2/organizations/{org}/jobs/{jobID}/log pattern — without needing pipeline or build context up front.

- introduces OrgScopedJobAPI with GetJobByOrg and GetJobLogByOrg
- adds Client.NewReaderByJobID(ctx, org, job, ttl, forceRefresh) for cached Parquet log access by job UUID alone
- resolves pipeline/build from the job’s build_url via ResolveJobLocation so Parquet cache keys stay compatible with existing MCP and pipeline-scoped callers
- refactors downloadAndCache to accept a BuildkiteAPI parameter, enabling an internal adapter that fetches via org endpoints while caching under the resolved {org}-{pipeline}-{build}-{job} key

### Context

The Buildkite CLI and MCP server both need efficient, searchable job logs. The CLI already uses org-scoped job endpoints; MCP uses buildkite-logs with full pipeline/build context. 

This change allows `bk` to eventually use the same Parquet cache and log tooling as MCP.
