### PR TITLE
feat: harden durable cache generation

### DIFF
--- a/blob_storage.go
+++ b/blob_storage.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,8 +35,7 @@ type BlobMetadata struct {
 	LogSize      int64     `json:"log_size_bytes,omitempty"`
 	ParquetSize  int64     `json:"parquet_size_bytes,omitempty"`
 	RowCount     int       `json:"row_count,omitempty"`
-	ProcessedAt  time.Time `json:"processed_at,omitempty"`
-	Status       string    `json:"status,omitempty"`
+	ProcessedAt  time.Time `json:"processed_at"`
 }
 
 // BlobStorageOptions contains configuration options for blob storage
@@ -211,9 +211,6 @@ func (bs *BlobStorage) WriteWithMetadataFrom(ctx context.Context, key string, r 
 		if !metadata.ProcessedAt.IsZero() {
 			opts.Metadata["processed_at"] = metadata.ProcessedAt.Format(time.RFC3339)
 		}
-		if metadata.Status != "" {
-			opts.Metadata["status"] = metadata.Status
-		}
 	}
 
 	writer, err := bs.bucket.NewWriter(ctx, key, opts)
@@ -264,21 +261,20 @@ func (bs *BlobStorage) ReadWithMetadata(ctx context.Context, key string) (*BlobM
 			}
 		}
 		if logSizeStr := attrMap["log_size_bytes"]; logSizeStr != "" {
-			if _, err := fmt.Sscanf(logSizeStr, "%d", &metadata.LogSize); err != nil {
-				metadata.LogSize = 0
+			if logSize, err := strconv.ParseInt(logSizeStr, 10, 64); err == nil {
+				metadata.LogSize = logSize
 			}
 		}
 		if parquetSizeStr := attrMap["parquet_size_bytes"]; parquetSizeStr != "" {
-			if _, err := fmt.Sscanf(parquetSizeStr, "%d", &metadata.ParquetSize); err != nil {
-				metadata.ParquetSize = 0
+			if parquetSize, err := strconv.ParseInt(parquetSizeStr, 10, 64); err == nil {
+				metadata.ParquetSize = parquetSize
 			}
 		}
 		if rowCountStr := attrMap["row_count"]; rowCountStr != "" {
-			if _, err := fmt.Sscanf(rowCountStr, "%d", &metadata.RowCount); err != nil {
-				metadata.RowCount = 0
+			if rowCount, err := strconv.Atoi(rowCountStr); err == nil {
+				metadata.RowCount = rowCount
 			}
 		}
-		metadata.Status = attrMap["status"]
 	}
 
 	return metadata, nil

--- a/blob_storage.go
+++ b/blob_storage.go
@@ -1,6 +1,7 @@
 package buildkitelogs
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -30,6 +31,11 @@ type BlobMetadata struct {
 	Organization string    `json:"organization"`
 	Pipeline     string    `json:"pipeline"`
 	Build        string    `json:"build"`
+	LogSize      int64     `json:"log_size_bytes,omitempty"`
+	ParquetSize  int64     `json:"parquet_size_bytes,omitempty"`
+	RowCount     int       `json:"row_count,omitempty"`
+	ProcessedAt  time.Time `json:"processed_at,omitempty"`
+	Status       string    `json:"status,omitempty"`
 }
 
 // BlobStorageOptions contains configuration options for blob storage
@@ -175,6 +181,11 @@ func (bs *BlobStorage) Exists(ctx context.Context, key string) (bool, error) {
 
 // WriteWithMetadata writes data to blob storage with metadata
 func (bs *BlobStorage) WriteWithMetadata(ctx context.Context, key string, data []byte, metadata *BlobMetadata) error {
+	return bs.WriteWithMetadataFrom(ctx, key, bytes.NewReader(data), metadata)
+}
+
+// WriteWithMetadataFrom streams data to blob storage with metadata.
+func (bs *BlobStorage) WriteWithMetadataFrom(ctx context.Context, key string, r io.Reader, metadata *BlobMetadata) error {
 	opts := &blob.WriterOptions{}
 
 	if metadata != nil {
@@ -188,6 +199,21 @@ func (bs *BlobStorage) WriteWithMetadata(ctx context.Context, key string, data [
 			"pipeline":     metadata.Pipeline,
 			"build":        metadata.Build,
 		}
+		if metadata.LogSize > 0 {
+			opts.Metadata["log_size_bytes"] = fmt.Sprintf("%d", metadata.LogSize)
+		}
+		if metadata.ParquetSize > 0 {
+			opts.Metadata["parquet_size_bytes"] = fmt.Sprintf("%d", metadata.ParquetSize)
+		}
+		if metadata.RowCount > 0 {
+			opts.Metadata["row_count"] = fmt.Sprintf("%d", metadata.RowCount)
+		}
+		if !metadata.ProcessedAt.IsZero() {
+			opts.Metadata["processed_at"] = metadata.ProcessedAt.Format(time.RFC3339)
+		}
+		if metadata.Status != "" {
+			opts.Metadata["status"] = metadata.Status
+		}
 	}
 
 	writer, err := bs.bucket.NewWriter(ctx, key, opts)
@@ -195,7 +221,7 @@ func (bs *BlobStorage) WriteWithMetadata(ctx context.Context, key string, data [
 		return fmt.Errorf("failed to create blob writer: %w", err)
 	}
 
-	if _, err := writer.Write(data); err != nil {
+	if _, err := io.Copy(writer, r); err != nil {
 		writer.Close()
 		return fmt.Errorf("failed to write blob data: %w", err)
 	}
@@ -232,6 +258,27 @@ func (bs *BlobStorage) ReadWithMetadata(ctx context.Context, key string) (*BlobM
 				metadata.CachedAt = cachedAt
 			}
 		}
+		if processedAtStr := attrMap["processed_at"]; processedAtStr != "" {
+			if processedAt, err := time.Parse(time.RFC3339, processedAtStr); err == nil {
+				metadata.ProcessedAt = processedAt
+			}
+		}
+		if logSizeStr := attrMap["log_size_bytes"]; logSizeStr != "" {
+			if _, err := fmt.Sscanf(logSizeStr, "%d", &metadata.LogSize); err != nil {
+				metadata.LogSize = 0
+			}
+		}
+		if parquetSizeStr := attrMap["parquet_size_bytes"]; parquetSizeStr != "" {
+			if _, err := fmt.Sscanf(parquetSizeStr, "%d", &metadata.ParquetSize); err != nil {
+				metadata.ParquetSize = 0
+			}
+		}
+		if rowCountStr := attrMap["row_count"]; rowCountStr != "" {
+			if _, err := fmt.Sscanf(rowCountStr, "%d", &metadata.RowCount); err != nil {
+				metadata.RowCount = 0
+			}
+		}
+		metadata.Status = attrMap["status"]
 	}
 
 	return metadata, nil

--- a/blob_storage_test.go
+++ b/blob_storage_test.go
@@ -2,6 +2,7 @@ package buildkitelogs
 
 import (
 	"context"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -67,6 +68,68 @@ func TestBlobStorage(t *testing.T) {
 
 	if readMetadata.IsTerminal != metadata.IsTerminal {
 		t.Errorf("Expected IsTerminal %t, got %t", metadata.IsTerminal, readMetadata.IsTerminal)
+	}
+}
+
+func TestBlobStorage_WriteWithMetadataFrom(t *testing.T) {
+	ctx := context.Background()
+	tempDir, err := os.MkdirTemp("", "bklog-blob-stream-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	blobStorage, err := NewBlobStorage(ctx, "file://"+tempDir, nil)
+	if err != nil {
+		t.Fatalf("Failed to create blob storage: %v", err)
+	}
+	defer blobStorage.Close()
+
+	key := "test-stream.parquet"
+	testData := "streamed parquet data"
+	metadata := &BlobMetadata{
+		JobID:        "abc-def",
+		JobState:     "finished",
+		IsTerminal:   true,
+		CachedAt:     time.Now(),
+		TTL:          "30s",
+		Organization: "test-org",
+		Pipeline:     "test-pipeline",
+		Build:        "123",
+		LogSize:      int64(len(testData)),
+		ParquetSize:  int64(len(testData)),
+		RowCount:     7,
+		ProcessedAt:  time.Now(),
+		Status:       "success",
+	}
+
+	if err := blobStorage.WriteWithMetadataFrom(ctx, key, strings.NewReader(testData), metadata); err != nil {
+		t.Fatalf("WriteWithMetadataFrom: %v", err)
+	}
+
+	reader, err := blobStorage.Reader(ctx, key)
+	if err != nil {
+		t.Fatalf("Reader: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != testData {
+		t.Fatalf("blob data = %q, want %q", string(got), testData)
+	}
+
+	readMetadata, err := blobStorage.ReadWithMetadata(ctx, key)
+	if err != nil {
+		t.Fatalf("ReadWithMetadata: %v", err)
+	}
+	if readMetadata.RowCount != metadata.RowCount {
+		t.Fatalf("RowCount = %d, want %d", readMetadata.RowCount, metadata.RowCount)
+	}
+	if readMetadata.Status != metadata.Status {
+		t.Fatalf("Status = %q, want %q", readMetadata.Status, metadata.Status)
 	}
 }
 

--- a/blob_storage_test.go
+++ b/blob_storage_test.go
@@ -100,7 +100,6 @@ func TestBlobStorage_WriteWithMetadataFrom(t *testing.T) {
 		ParquetSize:  int64(len(testData)),
 		RowCount:     7,
 		ProcessedAt:  time.Now(),
-		Status:       "success",
 	}
 
 	if err := blobStorage.WriteWithMetadataFrom(ctx, key, strings.NewReader(testData), metadata); err != nil {
@@ -127,9 +126,6 @@ func TestBlobStorage_WriteWithMetadataFrom(t *testing.T) {
 	}
 	if readMetadata.RowCount != metadata.RowCount {
 		t.Fatalf("RowCount = %d, want %d", readMetadata.RowCount, metadata.RowCount)
-	}
-	if readMetadata.Status != metadata.Status {
-		t.Fatalf("Status = %q, want %q", readMetadata.Status, metadata.Status)
 	}
 }
 

--- a/buildkite_api.go
+++ b/buildkite_api.go
@@ -84,6 +84,9 @@ func (c *BuildkiteAPIClient) GetJobLog(ctx context.Context, org, pipeline, build
 	reader, writer := io.Pipe()
 	go func() {
 		_, err := c.client.Do(req, writer)
+		if err != nil {
+			err = &logDownloadError{err: err}
+		}
 		_ = writer.CloseWithError(err)
 	}()
 

--- a/buildkite_api.go
+++ b/buildkite_api.go
@@ -31,7 +31,9 @@ type BuildkiteAPI interface {
 // BuildkiteAPIClient provides methods to interact with the Buildkite API
 // Now wraps the official go-buildkite v4 client
 type BuildkiteAPIClient struct {
-	client *buildkite.Client
+	client       *buildkite.Client
+	requireToken bool
+	apiToken     string
 }
 
 // NewBuildkiteAPIClient creates a new Buildkite API client using go-buildkite v4
@@ -49,7 +51,9 @@ func NewBuildkiteAPIClient(apiToken, version string) *BuildkiteAPIClient {
 	)
 
 	return &BuildkiteAPIClient{
-		client: client,
+		client:       client,
+		requireToken: true,
+		apiToken:     apiToken,
 	}
 }
 
@@ -66,13 +70,24 @@ func NewBuildkiteAPIExistingClient(client *buildkite.Client) *BuildkiteAPIClient
 // build: build number or UUID
 // job: job ID
 func (c *BuildkiteAPIClient) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
-	jobLog, _, err := c.client.Jobs.GetJobLog(ctx, org, pipeline, build, job)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get job log: %w", err)
+	if c.requireToken && c.apiToken == "" {
+		return nil, fmt.Errorf("missing Buildkite API token")
 	}
 
-	// Convert JobLog content to io.ReadCloser
-	return io.NopCloser(strings.NewReader(jobLog.Content)), nil
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, build, job)
+	req, err := c.client.NewRequest(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create job log request: %w", err)
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	reader, writer := io.Pipe()
+	go func() {
+		_, err := c.client.Do(req, writer)
+		_ = writer.CloseWithError(err)
+	}()
+
+	return reader, nil
 }
 
 // GetJobStatus gets the current status of a job

--- a/buildkite_api_test.go
+++ b/buildkite_api_test.go
@@ -3,6 +3,7 @@ package buildkitelogs
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -200,5 +201,46 @@ func TestGetJobLog_NoToken(t *testing.T) {
 	// We just check that an error occurred
 	if err == nil {
 		t.Error("Expected an error when API token is empty")
+	}
+}
+
+func TestGetJobLog_StreamsPlainText(t *testing.T) {
+	const logContent = "\x1b_bk;t=1745322209921\x07first line\nsecond line\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/organizations/org/pipelines/pipeline/builds/123/jobs/job-1/log" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "text/plain" {
+			t.Errorf("Accept = %q, want text/plain", got)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		if _, err := io.WriteString(w, logContent); err != nil {
+			t.Errorf("WriteString: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	bkClient, err := buildkite.NewOpts(
+		buildkite.WithBaseURL(server.URL),
+		buildkite.WithTokenAuth("test-token"),
+	)
+	if err != nil {
+		t.Fatalf("NewOpts: %v", err)
+	}
+
+	apiClient := NewBuildkiteAPIExistingClient(bkClient)
+	reader, err := apiClient.GetJobLog(t.Context(), "org", "pipeline", "123", "job-1")
+	if err != nil {
+		t.Fatalf("GetJobLog: %v", err)
+	}
+	defer reader.Close()
+
+	got, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != logContent {
+		t.Fatalf("log content = %q, want %q", string(got), logContent)
 	}
 }

--- a/cache.go
+++ b/cache.go
@@ -30,20 +30,3 @@ func createLocalCacheFile(ctx context.Context, blobStorage *BlobStorage, blobKey
 
 	return cacheFilePath.Name(), nil
 }
-
-// createLocalCacheFileFromData creates a local temp file directly from in-memory data,
-// avoiding a redundant round-trip through blob storage.
-func createLocalCacheFileFromData(data []byte) (string, error) {
-	cacheFile, err := os.CreateTemp("", "bklog-")
-	if err != nil {
-		return "", fmt.Errorf("failed to create local cache file: %w", err)
-	}
-	defer cacheFile.Close()
-
-	if _, err := cacheFile.Write(data); err != nil {
-		os.Remove(cacheFile.Name()) //nolint:gosec // path from os.CreateTemp, not user input
-		return "", fmt.Errorf("failed to write local cache file: %w", err)
-	}
-
-	return cacheFile.Name(), nil
-}

--- a/client.go
+++ b/client.go
@@ -292,8 +292,7 @@ func (c *Client) cacheUsable(ctx context.Context, blobKey string, ttl time.Durat
 		return true, nil
 	}
 
-	status := &JobStatus{IsTerminal: false}
-	return !status.ShouldRefreshCache(metadata.CachedAt, ttl), nil
+	return time.Since(metadata.CachedAt) <= ttl, nil
 }
 
 func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string, ttl time.Duration, blobKey string) error {
@@ -390,7 +389,6 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 		ParquetSize:  parquetSize,
 		RowCount:     logEntries,
 		ProcessedAt:  time.Now(),
-		Status:       "success",
 	}
 	parquetReader, err := os.Open(tempPath) //nolint:gosec // path from os.CreateTemp, not user input
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/buildkite/go-buildkite/v5"
+	"golang.org/x/sync/singleflight"
 )
 
 // ErrLogTooLarge is returned when a job log exceeds the configured maximum size.
@@ -37,6 +38,18 @@ type AfterLogParsingFunc func(ctx context.Context, result *LogParsingResult)
 type AfterBlobStorageFunc func(ctx context.Context, result *BlobStorageResult)
 type AfterLocalCacheFunc func(ctx context.Context, result *LocalCacheResult)
 
+// Stage identifies the processing stage reported by hooks.
+type Stage string
+
+const (
+	StageCacheCheck  Stage = "cache_check"
+	StageJobStatus   Stage = "job_status"
+	StageLogDownload Stage = "log_download"
+	StageLogParsing  Stage = "log_parsing"
+	StageBlobStorage Stage = "blob_storage"
+	StageLocalCache  Stage = "local_cache"
+)
+
 // Hooks contains all registered hook functions
 type Hooks struct {
 	OnAfterCacheCheck  []AfterCacheCheckFunc
@@ -51,6 +64,9 @@ type Hooks struct {
 type BaseResult struct {
 	Org, Pipeline, Build, Job string
 	Duration                  time.Duration
+	Stage                     Stage
+	Success                   bool
+	Err                       error
 }
 
 // CacheCheckResult contains the result of checking blob storage cache
@@ -122,11 +138,12 @@ func (h *Hooks) AddAfterLocalCache(hook AfterLocalCacheFunc) {
 
 // Client provides a high-level convenience API for common buildkite-logs-parquet operations
 type Client struct {
-	api         BuildkiteAPI
-	storageURL  string
-	blobStorage *BlobStorage
-	hooks       *Hooks
-	maxLogBytes int64 // 0 means no limit
+	api          BuildkiteAPI
+	storageURL   string
+	blobStorage  *BlobStorage
+	hooks        *Hooks
+	maxLogBytes  int64 // 0 means no limit
+	refreshGroup singleflight.Group
 }
 
 // NewClient creates a new Client using the provided go-buildkite client
@@ -227,188 +244,138 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 
 	blobKey := GenerateBlobKey(org, pipeline, build, job)
 
-	// Check if blob already exists
 	cacheCheckStart := time.Now()
 	exists, err := c.blobStorage.Exists(ctx, blobKey)
+	cacheCheckDuration := time.Since(cacheCheckStart)
+	c.fireCacheCheckHook(ctx, org, pipeline, build, job, cacheCheckDuration, blobKey, exists, err)
 	if err != nil {
 		return "", fmt.Errorf("failed to check blob existence: %w", err)
 	}
 
-	cacheCheckDuration := time.Since(cacheCheckStart)
-
-	// Call after cache check hooks
-	for _, hook := range c.hooks.OnAfterCacheCheck {
-		hook(ctx, &CacheCheckResult{
-			BaseResult: BaseResult{
-				Org:      org,
-				Pipeline: pipeline,
-				Build:    build,
-				Job:      job,
-				Duration: cacheCheckDuration,
-			},
-			BlobKey: blobKey,
-			Exists:  exists,
-		})
-	}
-
-	// Get job status to determine caching strategy
-	jobStatusStart := time.Now()
-	jobStatus, err := api.GetJobStatus(ctx, org, pipeline, build, job)
-	if err != nil {
-		return "", fmt.Errorf("failed to get job status: %w", err)
-	}
-
-	jobStatusDuration := time.Since(jobStatusStart)
-
-	// Call after job status hooks
-	for _, hook := range c.hooks.OnAfterJobStatus {
-		hook(ctx, &JobStatusResult{
-			BaseResult: BaseResult{
-				Org:      org,
-				Pipeline: pipeline,
-				Build:    build,
-				Job:      job,
-				Duration: jobStatusDuration,
-			},
-			JobStatus: jobStatus,
-		})
-	}
-
-	// Check if we should use existing cache
 	if exists && !forceRefresh {
-		metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
-		if err == nil && metadata != nil {
-			// For terminal jobs, always use cache
-			if metadata.IsTerminal {
-				return createLocalCacheFile(ctx, c.blobStorage, blobKey)
-			}
-
-			// For non-terminal jobs, check TTL
-			timeElapsed := time.Since(metadata.CachedAt)
-			if timeElapsed < ttl {
-				return createLocalCacheFile(ctx, c.blobStorage, blobKey)
-			}
+		if usable, err := c.cacheUsable(ctx, blobKey, ttl); err == nil && usable {
+			return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 		}
 	}
 
-	// Download fresh logs from API
+	inflightKey := blobKey
+	if forceRefresh {
+		inflightKey += ":force"
+	}
+
+	ch := c.refreshGroup.DoChan(inflightKey, func() (any, error) {
+		if !forceRefresh {
+			if usable, err := c.cacheUsable(ctx, blobKey, ttl); err == nil && usable {
+				return nil, nil
+			}
+		}
+		return nil, c.refreshBlobCache(ctx, api, org, pipeline, build, job, ttl, blobKey)
+	})
+
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case result := <-ch:
+		if result.Err != nil {
+			return "", result.Err
+		}
+	}
+
+	return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
+}
+
+func (c *Client) cacheUsable(ctx context.Context, blobKey string, ttl time.Duration) (bool, error) {
+	metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
+	if err != nil || metadata == nil {
+		return false, err
+	}
+	if metadata.IsTerminal {
+		return true, nil
+	}
+
+	status := &JobStatus{IsTerminal: false}
+	return !status.ShouldRefreshCache(metadata.CachedAt, ttl), nil
+}
+
+func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string, ttl time.Duration, blobKey string) error {
+	jobStatusStart := time.Now()
+	jobStatus, err := api.GetJobStatus(ctx, org, pipeline, build, job)
+	jobStatusDuration := time.Since(jobStatusStart)
+	c.fireJobStatusHook(ctx, org, pipeline, build, job, jobStatusDuration, jobStatus, err)
+	if err != nil {
+		return fmt.Errorf("failed to get job status: %w", err)
+	}
+
 	logDownloadStart := time.Now()
 	logReader, err := api.GetJobLog(ctx, org, pipeline, build, job)
+	logDownloadDuration := time.Since(logDownloadStart)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch logs from API: %w", err)
+		c.fireLogDownloadHook(ctx, org, pipeline, build, job, logDownloadDuration, 0, err)
+		return fmt.Errorf("failed to fetch logs from API: %w", err)
 	}
 	defer logReader.Close()
 
-	logDownloadDuration := time.Since(logDownloadStart)
-
 	var logSize int64
-	if logReader != nil {
-		// Get content length if available
-		if seeker, ok := logReader.(io.Seeker); ok {
-			if size, seekErr := seeker.Seek(0, 2); seekErr == nil {
-				logSize = size
-				if _, resetErr := seeker.Seek(0, 0); resetErr != nil {
-					// If we can't reset, continue anyway - the reader might still work
-					logSize = 0
-				}
+	if seeker, ok := logReader.(io.Seeker); ok {
+		if size, seekErr := seeker.Seek(0, io.SeekEnd); seekErr == nil {
+			logSize = size
+			if _, resetErr := seeker.Seek(0, io.SeekStart); resetErr != nil {
+				logSize = 0
 			}
 		}
 	}
 
-	// Enforce max log size limit
+	var limitedReader *limitedReadCloser
 	if c.maxLogBytes > 0 {
-		// If we know the size upfront, fail fast
 		if logSize > c.maxLogBytes {
-			return "", fmt.Errorf("%w: %d bytes exceeds limit of %d bytes", ErrLogTooLarge, logSize, c.maxLogBytes)
+			err := fmt.Errorf("%w: %d bytes exceeds limit of %d bytes", ErrLogTooLarge, logSize, c.maxLogBytes)
+			c.fireLogDownloadHook(ctx, org, pipeline, build, job, logDownloadDuration, logSize, err)
+			return err
 		}
-		// Wrap reader to enforce limit during streaming
-		logReader = &limitedReadCloser{
+		limitedReader = &limitedReadCloser{
 			rc:    logReader,
 			r:     io.LimitReader(logReader, c.maxLogBytes+1),
 			limit: c.maxLogBytes,
 		}
+		logReader = limitedReader
 	}
+	c.fireLogDownloadHook(ctx, org, pipeline, build, job, logDownloadDuration, logSize, nil)
 
-	// Call after log download hooks
-	for _, hook := range c.hooks.OnAfterLogDownload {
-		hook(ctx, &LogDownloadResult{
-			BaseResult: BaseResult{
-				Org:      org,
-				Pipeline: pipeline,
-				Build:    build,
-				Job:      job,
-				Duration: logDownloadDuration,
-			},
-			LogSize: logSize,
-		})
-	}
-
-	// Parse logs and convert to parquet data
 	logParsingStart := time.Now()
 	parser := NewParser()
-	var parquetData []byte
-
-	// Create a temporary file for parquet export
 	tempFile, err := os.CreateTemp("", "bklog-*.parquet")
 	if err != nil {
-		return "", fmt.Errorf("failed to create temp file: %w", err)
+		logParsingDuration := time.Since(logParsingStart)
+		c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, 0, 0, err)
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tempPath := tempFile.Name()
+	if err := tempFile.Close(); err != nil {
+		logParsingDuration := time.Since(logParsingStart)
+		c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, 0, 0, err)
+		return fmt.Errorf("failed to close temp file before export: %w", err)
+	}
 	defer func() {
-		tempFile.Close()
-		os.Remove(tempPath)
+		_ = os.Remove(tempPath)
 	}()
 
-	// Export logs to parquet using streaming approach
-	if err := ExportSeq2ToParquet(parser.All(logReader), tempPath); err != nil {
-		logParsingDuration := time.Since(logParsingStart)
-
-		// Call after log parsing hooks (with error)
-		for _, hook := range c.hooks.OnAfterLogParsing {
-			hook(ctx, &LogParsingResult{
-				BaseResult: BaseResult{
-					Org:      org,
-					Pipeline: pipeline,
-					Build:    build,
-					Job:      job,
-					Duration: logParsingDuration,
-				},
-				ParquetSize: 0,
-				LogEntries:  0,
-			})
-		}
-		return "", fmt.Errorf("failed to export logs to parquet: %w", err)
-	}
-
-	err = tempFile.Close()
-	if err != nil {
-		return "", fmt.Errorf("failed to close temp file: %w", err)
-	}
-
-	// Read the parquet data
-	parquetData, err = os.ReadFile(tempPath) //nolint:gosec // path from os.CreateTemp, not user input
-	if err != nil {
-		return "", fmt.Errorf("failed to read parquet data: %w", err)
-	}
-
+	logEntries, err := ExportSeq2ToParquetWithFilterAndStats(parser.All(logReader), tempPath, nil)
 	logParsingDuration := time.Since(logParsingStart)
-
-	// Call after log parsing hooks
-	for _, hook := range c.hooks.OnAfterLogParsing {
-		hook(ctx, &LogParsingResult{
-			BaseResult: BaseResult{
-				Org:      org,
-				Pipeline: pipeline,
-				Build:    build,
-				Job:      job,
-				Duration: logParsingDuration,
-			},
-			ParquetSize: int64(len(parquetData)),
-			LogEntries:  0, // Consumer can count if needed
-		})
+	if err != nil {
+		c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, 0, logEntries, err)
+		return fmt.Errorf("failed to export logs to parquet: %w", err)
 	}
+	fileInfo, err := os.Stat(tempPath) //nolint:gosec // path from os.CreateTemp, not user input
+	if err != nil {
+		c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, 0, logEntries, err)
+		return fmt.Errorf("failed to measure parquet data: %w", err)
+	}
+	parquetSize := fileInfo.Size()
+	if limitedReader != nil && logSize == 0 {
+		logSize = limitedReader.consumed
+	}
+	c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, parquetSize, logEntries, nil)
 
-	// Store in blob storage with metadata
 	blobStorageStart := time.Now()
 	metadata := &BlobMetadata{
 		JobID:        job,
@@ -419,16 +386,125 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		Organization: org,
 		Pipeline:     pipeline,
 		Build:        build,
+		LogSize:      logSize,
+		ParquetSize:  parquetSize,
+		RowCount:     logEntries,
+		ProcessedAt:  time.Now(),
+		Status:       "success",
 	}
-
-	err = c.blobStorage.WriteWithMetadata(ctx, blobKey, parquetData, metadata)
+	parquetReader, err := os.Open(tempPath) //nolint:gosec // path from os.CreateTemp, not user input
 	if err != nil {
-		return "", fmt.Errorf("failed to write to blob storage: %w", err)
+		blobStorageDuration := time.Since(blobStorageStart)
+		c.fireBlobStorageHook(ctx, org, pipeline, build, job, blobStorageDuration, blobKey, parquetSize, jobStatus.IsTerminal, ttl, err)
+		return fmt.Errorf("failed to open parquet data: %w", err)
+	}
+	defer parquetReader.Close()
+
+	err = c.blobStorage.WriteWithMetadataFrom(ctx, blobKey, parquetReader, metadata)
+	blobStorageDuration := time.Since(blobStorageStart)
+	c.fireBlobStorageHook(ctx, org, pipeline, build, job, blobStorageDuration, blobKey, parquetSize, jobStatus.IsTerminal, ttl, err)
+	if err != nil {
+		return fmt.Errorf("failed to write to blob storage: %w", err)
 	}
 
-	blobStorageDuration := time.Since(blobStorageStart)
+	return nil
+}
 
-	// Call after blob storage hooks
+func (c *Client) createLocalCacheFileWithHooks(ctx context.Context, org, pipeline, build, job, blobKey string) (string, error) {
+	localCacheStart := time.Now()
+	localPath, err := createLocalCacheFile(ctx, c.blobStorage, blobKey)
+	localCacheDuration := time.Since(localCacheStart)
+
+	var fileSize int64
+	if err == nil {
+		if stat, statErr := os.Stat(localPath); statErr == nil { //nolint:gosec // path from createLocalCacheFile, not user input
+			fileSize = stat.Size()
+		}
+	}
+
+	c.fireLocalCacheHook(ctx, org, pipeline, build, job, localCacheDuration, localPath, fileSize, err)
+	if err != nil {
+		return "", fmt.Errorf("failed to create local cache file: %w", err)
+	}
+
+	return localPath, nil
+}
+
+func (c *Client) fireCacheCheckHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, blobKey string, exists bool, err error) {
+	for _, hook := range c.hooks.OnAfterCacheCheck {
+		hook(ctx, &CacheCheckResult{
+			BaseResult: BaseResult{
+				Org:      org,
+				Pipeline: pipeline,
+				Build:    build,
+				Job:      job,
+				Duration: duration,
+				Stage:    StageCacheCheck,
+				Success:  err == nil,
+				Err:      err,
+			},
+			BlobKey: blobKey,
+			Exists:  exists,
+		})
+	}
+}
+
+func (c *Client) fireJobStatusHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, jobStatus *JobStatus, err error) {
+	for _, hook := range c.hooks.OnAfterJobStatus {
+		hook(ctx, &JobStatusResult{
+			BaseResult: BaseResult{
+				Org:      org,
+				Pipeline: pipeline,
+				Build:    build,
+				Job:      job,
+				Duration: duration,
+				Stage:    StageJobStatus,
+				Success:  err == nil,
+				Err:      err,
+			},
+			JobStatus: jobStatus,
+		})
+	}
+}
+
+func (c *Client) fireLogDownloadHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, logSize int64, err error) {
+	for _, hook := range c.hooks.OnAfterLogDownload {
+		hook(ctx, &LogDownloadResult{
+			BaseResult: BaseResult{
+				Org:      org,
+				Pipeline: pipeline,
+				Build:    build,
+				Job:      job,
+				Duration: duration,
+				Stage:    StageLogDownload,
+				Success:  err == nil,
+				Err:      err,
+			},
+			LogSize: logSize,
+		})
+	}
+}
+
+func (c *Client) fireLogParsingHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, parquetSize int64, logEntries int, err error) {
+	for _, hook := range c.hooks.OnAfterLogParsing {
+		hook(ctx, &LogParsingResult{
+			BaseResult: BaseResult{
+				Org:      org,
+				Pipeline: pipeline,
+				Build:    build,
+				Job:      job,
+				Duration: duration,
+				Stage:    StageLogParsing,
+				Success:  err == nil,
+				Err:      err,
+			},
+			ParquetSize: parquetSize,
+			LogEntries:  logEntries,
+		})
+	}
+}
+
+func (c *Client) fireBlobStorageHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, blobKey string, dataSize int64, isTerminal bool, ttl time.Duration, err error) {
 	for _, hook := range c.hooks.OnAfterBlobStorage {
 		hook(ctx, &BlobStorageResult{
 			BaseResult: BaseResult{
@@ -436,31 +512,20 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 				Pipeline: pipeline,
 				Build:    build,
 				Job:      job,
-				Duration: blobStorageDuration,
+				Duration: duration,
+				Stage:    StageBlobStorage,
+				Success:  err == nil,
+				Err:      err,
 			},
 			BlobKey:    blobKey,
-			DataSize:   int64(len(parquetData)),
-			IsTerminal: jobStatus.IsTerminal,
+			DataSize:   dataSize,
+			IsTerminal: isTerminal,
 			TTL:        ttl,
 		})
 	}
+}
 
-	// Create local cache file directly from in-memory data,
-	// avoiding a redundant blob storage read.
-	localCacheStart := time.Now()
-	localPath, err := createLocalCacheFileFromData(parquetData)
-	if err != nil {
-		return "", fmt.Errorf("failed to create local cache file: %w", err)
-	}
-
-	localCacheDuration := time.Since(localCacheStart)
-
-	var fileSize int64
-	if stat, statErr := os.Stat(localPath); statErr == nil { //nolint:gosec // path from createLocalCacheFileFromData, not user input
-		fileSize = stat.Size()
-	}
-
-	// Call after local cache hooks
+func (c *Client) fireLocalCacheHook(ctx context.Context, org, pipeline, build, job string, duration time.Duration, localPath string, fileSize int64, err error) {
 	for _, hook := range c.hooks.OnAfterLocalCache {
 		hook(ctx, &LocalCacheResult{
 			BaseResult: BaseResult{
@@ -468,14 +533,15 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 				Pipeline: pipeline,
 				Build:    build,
 				Job:      job,
-				Duration: localCacheDuration,
+				Duration: duration,
+				Stage:    StageLocalCache,
+				Success:  err == nil,
+				Err:      err,
 			},
 			LocalPath: localPath,
 			FileSize:  fileSize,
 		})
 	}
-
-	return localPath, nil
 }
 
 // limitedReadCloser wraps a reader with a size limit, returning ErrLogTooLarge

--- a/client.go
+++ b/client.go
@@ -258,17 +258,17 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		}
 	}
 
-	// singleflight uses the leader's context for the shared refresh. If that
-	// context is canceled, all waiters observe the same refresh failure; waiters
-	// can still abandon their own wait via the select below.
+	// Decouple shared refresh work from the single caller that wins the
+	// singleflight race. Waiters can still abandon their own wait below.
+	refreshCtx := context.WithoutCancel(ctx)
 	inflightKey := blobKey
 	ch := c.refreshGroup.DoChan(inflightKey, func() (any, error) {
 		if !forceRefresh {
-			if usable, err := c.cacheUsable(ctx, blobKey, ttl); err == nil && usable {
+			if usable, err := c.cacheUsable(refreshCtx, blobKey, ttl); err == nil && usable {
 				return nil, nil
 			}
 		}
-		return nil, c.refreshBlobCache(ctx, api, org, pipeline, build, job, ttl, blobKey)
+		return nil, c.refreshBlobCache(refreshCtx, api, org, pipeline, build, job, ttl, blobKey)
 	})
 
 	select {
@@ -338,7 +338,6 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 		}
 		logReader = limitedReader
 	}
-	c.fireLogDownloadHook(ctx, org, pipeline, build, job, logDownloadDuration, logSize, nil)
 
 	logParsingStart := time.Now()
 	parser := NewParser()
@@ -361,6 +360,13 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 	logEntries, err := ExportSeq2ToParquetWithFilterAndStats(parser.All(logReader), tempPath, nil)
 	logParsingDuration := time.Since(logParsingStart)
 	if err != nil {
+		if isLogDownloadError(err) {
+			if logSize == 0 {
+				logSize = countingReader.consumed
+			}
+			c.fireLogDownloadHook(ctx, org, pipeline, build, job, time.Since(logDownloadStart), logSize, err)
+			return fmt.Errorf("failed to fetch logs from API: %w", err)
+		}
 		c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, 0, logEntries, err)
 		return fmt.Errorf("failed to export logs to parquet: %w", err)
 	}
@@ -373,6 +379,7 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 	if logSize == 0 {
 		logSize = countingReader.consumed
 	}
+	c.fireLogDownloadHook(ctx, org, pipeline, build, job, time.Since(logDownloadStart), logSize, nil)
 	c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, parquetSize, logEntries, nil)
 
 	blobStorageStart := time.Now()
@@ -540,6 +547,23 @@ func (c *Client) fireLocalCacheHook(ctx context.Context, org, pipeline, build, j
 			FileSize:  fileSize,
 		})
 	}
+}
+
+type logDownloadError struct {
+	err error
+}
+
+func (e *logDownloadError) Error() string {
+	return e.err.Error()
+}
+
+func (e *logDownloadError) Unwrap() error {
+	return e.err
+}
+
+func isLogDownloadError(err error) bool {
+	var downloadErr *logDownloadError
+	return errors.As(err, &downloadErr) || errors.Is(err, ErrLogTooLarge)
 }
 
 // countingReadCloser tracks bytes consumed from a streaming log reader.

--- a/client.go
+++ b/client.go
@@ -258,11 +258,10 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		}
 	}
 
+	// singleflight uses the leader's context for the shared refresh. If that
+	// context is canceled, all waiters observe the same refresh failure; waiters
+	// can still abandon their own wait via the select below.
 	inflightKey := blobKey
-	if forceRefresh {
-		inflightKey += ":force"
-	}
-
 	ch := c.refreshGroup.DoChan(inflightKey, func() (any, error) {
 		if !forceRefresh {
 			if usable, err := c.cacheUsable(ctx, blobKey, ttl); err == nil && usable {
@@ -325,14 +324,15 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 		}
 	}
 
-	var limitedReader *limitedReadCloser
+	countingReader := &countingReadCloser{rc: logReader}
+	logReader = countingReader
 	if c.maxLogBytes > 0 {
 		if logSize > c.maxLogBytes {
 			err := fmt.Errorf("%w: %d bytes exceeds limit of %d bytes", ErrLogTooLarge, logSize, c.maxLogBytes)
 			c.fireLogDownloadHook(ctx, org, pipeline, build, job, logDownloadDuration, logSize, err)
 			return err
 		}
-		limitedReader = &limitedReadCloser{
+		limitedReader := &limitedReadCloser{
 			rc:    logReader,
 			r:     io.LimitReader(logReader, c.maxLogBytes+1),
 			limit: c.maxLogBytes,
@@ -371,8 +371,8 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 		return fmt.Errorf("failed to measure parquet data: %w", err)
 	}
 	parquetSize := fileInfo.Size()
-	if limitedReader != nil && logSize == 0 {
-		logSize = limitedReader.consumed
+	if logSize == 0 {
+		logSize = countingReader.consumed
 	}
 	c.fireLogParsingHook(ctx, org, pipeline, build, job, logParsingDuration, parquetSize, logEntries, nil)
 
@@ -542,6 +542,22 @@ func (c *Client) fireLocalCacheHook(ctx context.Context, org, pipeline, build, j
 			FileSize:  fileSize,
 		})
 	}
+}
+
+// countingReadCloser tracks bytes consumed from a streaming log reader.
+type countingReadCloser struct {
+	rc       io.ReadCloser
+	consumed int64
+}
+
+func (c *countingReadCloser) Read(p []byte) (int, error) {
+	n, err := c.rc.Read(p)
+	c.consumed += int64(n)
+	return n, err
+}
+
+func (c *countingReadCloser) Close() error {
+	return c.rc.Close()
 }
 
 // limitedReadCloser wraps a reader with a size limit, returning ErrLogTooLarge

--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/buildkite/go-buildkite/v5"
@@ -17,6 +18,8 @@ var ErrLogTooLarge = errors.New("log exceeds maximum allowed size")
 
 // DefaultMaxLogBytes is the default maximum log size (10MB).
 const DefaultMaxLogBytes int64 = 10 * 1024 * 1024
+
+const defaultStatusCacheTTL = 5 * time.Second
 
 // ClientOption configures a Client.
 type ClientOption func(*Client)
@@ -144,6 +147,13 @@ type Client struct {
 	hooks        *Hooks
 	maxLogBytes  int64 // 0 means no limit
 	refreshGroup singleflight.Group
+	statusGroup  singleflight.Group
+	statusCache  sync.Map // map[string]statusCacheEntry
+}
+
+type statusCacheEntry struct {
+	status    *JobStatus
+	fetchedAt time.Time
 }
 
 // NewClient creates a new Client using the provided go-buildkite client
@@ -253,7 +263,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 	}
 
 	if exists && !forceRefresh {
-		if usable, err := c.cacheUsable(ctx, blobKey, ttl); err == nil && usable {
+		if usable, err := c.cacheUsable(ctx, api, org, pipeline, build, job, blobKey, ttl); err == nil && usable {
 			return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 		}
 	}
@@ -264,7 +274,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 	inflightKey := blobKey
 	ch := c.refreshGroup.DoChan(inflightKey, func() (any, error) {
 		if !forceRefresh {
-			if usable, err := c.cacheUsable(refreshCtx, blobKey, ttl); err == nil && usable {
+			if usable, err := c.cacheUsable(refreshCtx, api, org, pipeline, build, job, blobKey, ttl); err == nil && usable {
 				return nil, nil
 			}
 		}
@@ -283,7 +293,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 	return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 }
 
-func (c *Client) cacheUsable(ctx context.Context, blobKey string, ttl time.Duration) (bool, error) {
+func (c *Client) cacheUsable(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job, blobKey string, ttl time.Duration) (bool, error) {
 	metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
 	if err != nil || metadata == nil {
 		return false, err
@@ -292,14 +302,67 @@ func (c *Client) cacheUsable(ctx context.Context, blobKey string, ttl time.Durat
 		return true, nil
 	}
 
+	status, err := c.getJobStatusMemoized(ctx, api, org, pipeline, build, job, blobKey)
+	if err != nil {
+		return false, err
+	}
+	if status.IsTerminal {
+		return false, nil
+	}
+
 	return time.Since(metadata.CachedAt) <= ttl, nil
 }
 
+func (c *Client) getJobStatusMemoized(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job, blobKey string) (*JobStatus, error) {
+	if entry, ok := c.loadCachedJobStatus(blobKey); ok {
+		return entry.status, nil
+	}
+
+	result, err, _ := c.statusGroup.Do(blobKey, func() (any, error) {
+		if entry, ok := c.loadCachedJobStatus(blobKey); ok {
+			return entry.status, nil
+		}
+
+		jobStatusStart := time.Now()
+		jobStatus, err := api.GetJobStatus(ctx, org, pipeline, build, job)
+		jobStatusDuration := time.Since(jobStatusStart)
+		c.fireJobStatusHook(ctx, org, pipeline, build, job, jobStatusDuration, jobStatus, err)
+		if err != nil {
+			return nil, err
+		}
+
+		c.statusCache.Store(blobKey, statusCacheEntry{
+			status:    jobStatus,
+			fetchedAt: time.Now(),
+		})
+		return jobStatus, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	status, ok := result.(*JobStatus)
+	if !ok || status == nil {
+		return nil, fmt.Errorf("memoized job status had unexpected type %T", result)
+	}
+	return status, nil
+}
+
+func (c *Client) loadCachedJobStatus(blobKey string) (statusCacheEntry, bool) {
+	value, ok := c.statusCache.Load(blobKey)
+	if !ok {
+		return statusCacheEntry{}, false
+	}
+	entry, ok := value.(statusCacheEntry)
+	if !ok || time.Since(entry.fetchedAt) > defaultStatusCacheTTL {
+		c.statusCache.Delete(blobKey)
+		return statusCacheEntry{}, false
+	}
+	return entry, true
+}
+
 func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string, ttl time.Duration, blobKey string) error {
-	jobStatusStart := time.Now()
-	jobStatus, err := api.GetJobStatus(ctx, org, pipeline, build, job)
-	jobStatusDuration := time.Since(jobStatusStart)
-	c.fireJobStatusHook(ctx, org, pipeline, build, job, jobStatusDuration, jobStatus, err)
+	jobStatus, err := c.getJobStatusMemoized(ctx, api, org, pipeline, build, job, blobKey)
 	if err != nil {
 		return fmt.Errorf("failed to get job status: %w", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,16 +19,49 @@ type mockBuildkiteAPI struct {
 	jobStatus      *JobStatus
 	getLogCalls    int
 	getStatusCalls int
+	logDelay       time.Duration
+	statusErr      error
+	logErr         error
+	mu             sync.Mutex
 }
 
 func (m *mockBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
+	if m.logDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(m.logDelay):
+		}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.getLogCalls++
+	if m.logErr != nil {
+		return nil, m.logErr
+	}
 	return io.NopCloser(strings.NewReader(m.logContent)), nil
 }
 
 func (m *mockBuildkiteAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.getStatusCalls++
+	if m.statusErr != nil {
+		return nil, m.statusErr
+	}
 	return m.jobStatus, nil
+}
+
+func (m *mockBuildkiteAPI) calls() (int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getLogCalls, m.getStatusCalls
+}
+
+func (m *mockBuildkiteAPI) setJobStatus(status *JobStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.jobStatus = status
 }
 
 func newTerminalMock() *mockBuildkiteAPI {
@@ -146,6 +180,134 @@ func TestClient_NewReader_CacheHit(t *testing.T) {
 
 	if mock.getLogCalls != initialLogCalls {
 		t.Errorf("expected no additional log downloads on cache hit, got %d extra calls", mock.getLogCalls-initialLogCalls)
+	}
+	if _, statusCalls := mock.calls(); statusCalls != 1 {
+		t.Errorf("expected terminal cache hit to skip job status, got %d status calls", statusCalls)
+	}
+}
+
+func TestClient_ConcurrentCacheMiss_SingleFlight(t *testing.T) {
+	mock := newTerminalMock()
+	mock.logDelay = 25 * time.Millisecond
+	client := newTestClient(t, mock)
+
+	const goroutines = 8
+	runConcurrentReaders(t, client, goroutines, false, time.Minute)
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 1 {
+		t.Fatalf("GetJobLog calls = %d, want 1", logCalls)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
+	}
+}
+
+func TestClient_ConcurrentTTLExpiry_RefreshOnce(t *testing.T) {
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07running log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+		logDelay:   25 * time.Millisecond,
+	}
+	client := newTestClient(t, mock)
+
+	reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Nanosecond, false)
+	if err != nil {
+		t.Fatalf("initial NewReader: %v", err)
+	}
+	defer reader.Close()
+	time.Sleep(time.Millisecond)
+
+	runConcurrentReaders(t, client, 8, false, time.Nanosecond)
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 2 {
+		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
+	}
+	if statusCalls != 2 {
+		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	}
+}
+
+func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
+	mock := newTerminalMock()
+	mock.logDelay = 25 * time.Millisecond
+	client := newTestClient(t, mock)
+
+	reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("initial NewReader: %v", err)
+	}
+	defer reader.Close()
+
+	runConcurrentReaders(t, client, 8, true, time.Minute)
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 2 {
+		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
+	}
+	if statusCalls != 2 {
+		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	}
+}
+
+func TestClient_NewReader_JobStatusErrorHook(t *testing.T) {
+	statusErr := errors.New("status unavailable")
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07Test log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+		statusErr:  statusErr,
+	}
+	client := newTestClient(t, mock)
+
+	var hookResult *JobStatusResult
+	client.Hooks().AddAfterJobStatus(func(ctx context.Context, r *JobStatusResult) {
+		hookResult = r
+	})
+
+	_, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err == nil {
+		t.Fatal("expected NewReader to fail")
+	}
+	if hookResult == nil {
+		t.Fatal("expected job status hook to fire")
+	}
+	if hookResult.Success {
+		t.Fatal("expected hook result to report failure")
+	}
+	if !errors.Is(hookResult.Err, statusErr) {
+		t.Fatalf("hook error = %v, want %v", hookResult.Err, statusErr)
+	}
+	if hookResult.Stage != StageJobStatus {
+		t.Fatalf("hook stage = %q, want %q", hookResult.Stage, StageJobStatus)
+	}
+}
+
+func runConcurrentReaders(t *testing.T, client *Client, goroutines int, forceRefresh bool, ttl time.Duration) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", ttl, forceRefresh)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer reader.Close()
+			if _, err := reader.GetFileInfo(); err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent NewReader failed: %v", err)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -20,12 +20,19 @@ type mockBuildkiteAPI struct {
 	getLogCalls    int
 	getStatusCalls int
 	logDelay       time.Duration
+	logStarted     chan struct{}
 	statusErr      error
 	logErr         error
 	mu             sync.Mutex
 }
 
 func (m *mockBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
+	if m.logStarted != nil {
+		select {
+		case m.logStarted <- struct{}{}:
+		default:
+		}
+	}
 	if m.logDelay > 0 {
 		select {
 		case <-ctx.Done():
@@ -311,6 +318,44 @@ func TestClient_ConcurrentForceAndTTLRefresh_Coalesce(t *testing.T) {
 	}
 }
 
+func TestClient_RefreshContinuesWhenSingleflightLeaderCancels(t *testing.T) {
+	mock := newTerminalMock()
+	mock.logDelay = 50 * time.Millisecond
+	mock.logStarted = make(chan struct{}, 1)
+	client := newTestClient(t, mock)
+
+	leaderCtx, cancelLeader := context.WithCancel(t.Context())
+	leaderErr := make(chan error, 1)
+	go func() {
+		reader, err := client.NewReader(leaderCtx, "org", "pipeline", "123", "job-1", time.Minute, false)
+		if reader != nil {
+			_ = reader.Close()
+		}
+		leaderErr <- err
+	}()
+
+	<-mock.logStarted
+	cancelLeader()
+
+	reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("follower NewReader: %v", err)
+	}
+	defer reader.Close()
+
+	if err := <-leaderErr; !errors.Is(err, context.Canceled) {
+		t.Fatalf("leader error = %v, want context.Canceled", err)
+	}
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 1 {
+		t.Fatalf("GetJobLog calls = %d, want 1", logCalls)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
+	}
+}
+
 func TestClient_NewReader_JobStatusErrorHook(t *testing.T) {
 	statusErr := errors.New("status unavailable")
 	mock := &mockBuildkiteAPI{
@@ -341,6 +386,73 @@ func TestClient_NewReader_JobStatusErrorHook(t *testing.T) {
 	if hookResult.Stage != StageJobStatus {
 		t.Fatalf("hook stage = %q, want %q", hookResult.Stage, StageJobStatus)
 	}
+}
+
+func TestClient_NewReader_LogDownloadStreamErrorHook(t *testing.T) {
+	downloadErr := errors.New("buildkite returned 500")
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07Test log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStatePassed, IsTerminal: true},
+	}
+	client := newTestClient(t, mock)
+	mock.logErr = nil
+
+	var downloadResult *LogDownloadResult
+	var parsingCalled bool
+	client.Hooks().AddAfterLogDownload(func(ctx context.Context, r *LogDownloadResult) {
+		downloadResult = r
+	})
+	client.Hooks().AddAfterLogParsing(func(ctx context.Context, r *LogParsingResult) {
+		parsingCalled = true
+	})
+
+	mockWithStreamErr := &streamErrorBuildkiteAPI{
+		status: mock.jobStatus,
+		err:    &logDownloadError{err: downloadErr},
+	}
+	client.api = mockWithStreamErr
+
+	_, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err == nil {
+		t.Fatal("expected NewReader to fail")
+	}
+	if downloadResult == nil {
+		t.Fatal("expected log download hook to fire")
+	}
+	if downloadResult.Success {
+		t.Fatal("expected log download hook to report failure")
+	}
+	if !errors.Is(downloadResult.Err, downloadErr) {
+		t.Fatalf("download hook error = %v, want %v", downloadResult.Err, downloadErr)
+	}
+	if parsingCalled {
+		t.Fatal("log parsing hook should not fire for stream download errors")
+	}
+}
+
+type streamErrorBuildkiteAPI struct {
+	status *JobStatus
+	err    error
+}
+
+func (a *streamErrorBuildkiteAPI) GetJobStatus(ctx context.Context, org, pipeline, build, job string) (*JobStatus, error) {
+	return a.status, nil
+}
+
+func (a *streamErrorBuildkiteAPI) GetJobLog(ctx context.Context, org, pipeline, build, job string) (io.ReadCloser, error) {
+	return &errorReadCloser{err: a.err}, nil
+}
+
+type errorReadCloser struct {
+	err error
+}
+
+func (r *errorReadCloser) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
+func (r *errorReadCloser) Close() error {
+	return nil
 }
 
 func runConcurrentReaders(t *testing.T, client *Client, goroutines int, forceRefresh bool, ttl time.Duration) {

--- a/client_test.go
+++ b/client_test.go
@@ -58,12 +58,6 @@ func (m *mockBuildkiteAPI) calls() (int, int) {
 	return m.getLogCalls, m.getStatusCalls
 }
 
-func (m *mockBuildkiteAPI) setJobStatus(status *JobStatus) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.jobStatus = status
-}
-
 func newTerminalMock() *mockBuildkiteAPI {
 	return &mockBuildkiteAPI{
 		logContent: "\x1b_bk;t=1745322209921\x07Test log entry\n",

--- a/client_test.go
+++ b/client_test.go
@@ -223,6 +223,25 @@ func TestClient_ConcurrentTTLExpiry_RefreshOnce(t *testing.T) {
 	}
 }
 
+func TestClient_NewReader_RecordsLogSizeWithoutLimit(t *testing.T) {
+	mock := newTerminalMock()
+	client := newTestClient(t, mock, WithMaxLogBytes(0))
+
+	reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer reader.Close()
+
+	metadata, err := client.blobStorage.ReadWithMetadata(t.Context(), GenerateBlobKey("org", "pipeline", "123", "job-1"))
+	if err != nil {
+		t.Fatalf("ReadWithMetadata: %v", err)
+	}
+	if metadata.LogSize != int64(len(mock.logContent)) {
+		t.Fatalf("LogSize = %d, want %d", metadata.LogSize, len(mock.logContent))
+	}
+}
+
 func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
 	mock := newTerminalMock()
 	mock.logDelay = 25 * time.Millisecond
@@ -235,6 +254,53 @@ func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
 	defer reader.Close()
 
 	runConcurrentReaders(t, client, 8, true, time.Minute)
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 2 {
+		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
+	}
+	if statusCalls != 2 {
+		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	}
+}
+
+func TestClient_ConcurrentForceAndTTLRefresh_Coalesce(t *testing.T) {
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07running log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+		logDelay:   25 * time.Millisecond,
+	}
+	client := newTestClient(t, mock)
+
+	reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Nanosecond, false)
+	if err != nil {
+		t.Fatalf("initial NewReader: %v", err)
+	}
+	defer reader.Close()
+	time.Sleep(time.Millisecond)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, forceRefresh := range []bool{false, true} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reader, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Nanosecond, forceRefresh)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer reader.Close()
+			if _, err := reader.GetFileInfo(); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent NewReader failed: %v", err)
+	}
 
 	logCalls, statusCalls := mock.calls()
 	if logCalls != 2 {

--- a/client_test.go
+++ b/client_test.go
@@ -65,6 +65,12 @@ func (m *mockBuildkiteAPI) calls() (int, int) {
 	return m.getLogCalls, m.getStatusCalls
 }
 
+func (m *mockBuildkiteAPI) setJobStatus(status *JobStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.jobStatus = status
+}
+
 func newTerminalMock() *mockBuildkiteAPI {
 	return &mockBuildkiteAPI{
 		logContent: "\x1b_bk;t=1745322209921\x07Test log entry\n",
@@ -225,8 +231,79 @@ func TestClient_ConcurrentTTLExpiry_RefreshOnce(t *testing.T) {
 	if logCalls != 2 {
 		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
 	}
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
+	}
+}
+
+func TestClient_NonTerminalCacheHit_StatusMemoized(t *testing.T) {
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07running log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+	}
+	client := newTestClient(t, mock)
+
+	reader1, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("first NewReader: %v", err)
+	}
+	defer reader1.Close()
+
+	reader2, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("second NewReader: %v", err)
+	}
+	defer reader2.Close()
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 1 {
+		t.Fatalf("GetJobLog calls = %d, want 1", logCalls)
+	}
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
+	}
+}
+
+func TestClient_NonTerminalCacheHit_RefreshesWhenStatusBecomesTerminal(t *testing.T) {
+	mock := &mockBuildkiteAPI{
+		logContent: "\x1b_bk;t=1745322209921\x07running log entry\n",
+		jobStatus:  &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+	}
+	client := newTestClient(t, mock)
+	blobKey := GenerateBlobKey("org", "pipeline", "123", "job-1")
+
+	reader1, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("first NewReader: %v", err)
+	}
+	defer reader1.Close()
+
+	mock.setJobStatus(&JobStatus{ID: "test-job", State: JobStatePassed, IsTerminal: true})
+	client.statusCache.Store(blobKey, statusCacheEntry{
+		status:    &JobStatus{ID: "test-job", State: JobStateRunning, IsTerminal: false},
+		fetchedAt: time.Now().Add(-defaultStatusCacheTTL - time.Second),
+	})
+
+	reader2, err := client.NewReader(t.Context(), "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("second NewReader: %v", err)
+	}
+	defer reader2.Close()
+
+	logCalls, statusCalls := mock.calls()
+	if logCalls != 2 {
+		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
+	}
 	if statusCalls != 2 {
 		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	}
+
+	metadata, err := client.blobStorage.ReadWithMetadata(t.Context(), blobKey)
+	if err != nil {
+		t.Fatalf("ReadWithMetadata: %v", err)
+	}
+	if !metadata.IsTerminal {
+		t.Fatal("expected final refresh to persist terminal metadata")
 	}
 }
 
@@ -266,8 +343,8 @@ func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
 	if logCalls != 2 {
 		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
 	}
-	if statusCalls != 2 {
-		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
 	}
 }
 
@@ -313,8 +390,8 @@ func TestClient_ConcurrentForceAndTTLRefresh_Coalesce(t *testing.T) {
 	if logCalls != 2 {
 		t.Fatalf("GetJobLog calls = %d, want 2", logCalls)
 	}
-	if statusCalls != 2 {
-		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	if statusCalls != 1 {
+		t.Fatalf("GetJobStatus calls = %d, want 1", statusCalls)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/apache/arrow-go/v18 v18.6.0
 	github.com/buildkite/go-buildkite/v5 v5.0.0
 	gocloud.dev v0.46.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -55,7 +56,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/parquet.go
+++ b/parquet.go
@@ -2,6 +2,7 @@ package buildkitelogs
 
 import (
 	"fmt"
+	"io"
 	"iter"
 	"os"
 
@@ -13,9 +14,9 @@ import (
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 )
 
-func createNewFileWriter(schema *arrow.Schema, file *os.File, pool memory.Allocator) (*pqarrow.FileWriter, error) {
+func createNewFileWriter(schema *arrow.Schema, w io.Writer, pool memory.Allocator) (*pqarrow.FileWriter, error) {
 	// Create Parquet writer
-	writer, err := pqarrow.NewFileWriter(schema, file,
+	writer, err := pqarrow.NewFileWriter(schema, w,
 		parquet.NewWriterProperties(
 			parquet.WithCompression(compress.Codecs.Zstd),
 		),
@@ -75,7 +76,6 @@ func (pw *ParquetWriter) createRecord(entries []*LogEntry) arrow.RecordBatch {
 
 // ParquetWriter provides streaming Parquet writing capabilities
 type ParquetWriter struct {
-	file   *os.File
 	writer *pqarrow.FileWriter
 	pool   memory.Allocator
 	schema *arrow.Schema
@@ -89,21 +89,25 @@ type ParquetWriter struct {
 
 // NewParquetWriter creates a new Parquet writer for streaming
 func NewParquetWriter(file *os.File) (*ParquetWriter, error) {
-	return newParquetWriterWithPool(file, memory.NewGoAllocator())
+	return NewParquetWriterForWriter(file)
+}
+
+// NewParquetWriterForWriter creates a new Parquet writer backed by any io.Writer.
+func NewParquetWriterForWriter(w io.Writer) (*ParquetWriter, error) {
+	return newParquetWriterWithPool(w, memory.NewGoAllocator())
 }
 
 // newParquetWriterWithPool creates a ParquetWriter using the provided allocator.
 // Used in tests to inject a memory.NewCheckedAllocator for leak detection.
-func newParquetWriterWithPool(file *os.File, pool memory.Allocator) (*ParquetWriter, error) {
+func newParquetWriterWithPool(w io.Writer, pool memory.Allocator) (*ParquetWriter, error) {
 	schema := createArrowSchema()
 
-	writer, err := createNewFileWriter(schema, file, pool)
+	writer, err := createNewFileWriter(schema, w, pool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Parquet writer: %w", err)
 	}
 
 	return &ParquetWriter{
-		file:   file,
 		writer: writer,
 		pool:   pool,
 		schema: schema,
@@ -141,29 +145,47 @@ func (pw *ParquetWriter) Close() error {
 
 // ExportSeq2ToParquet exports log entries using Go 1.23+ iter.Seq2 for efficient iteration
 func ExportSeq2ToParquet(seq iter.Seq2[*LogEntry, error], filename string) error {
-	return ExportSeq2ToParquetWithFilter(seq, filename, nil)
+	_, err := ExportSeq2ToParquetWithFilterAndStats(seq, filename, nil)
+	return err
 }
 
 // ExportSeq2ToParquetWithFilter exports filtered log entries using iter.Seq2
 func ExportSeq2ToParquetWithFilter(seq iter.Seq2[*LogEntry, error], filename string, filterFunc func(*LogEntry) bool) error {
+	_, err := ExportSeq2ToParquetWithFilterAndStats(seq, filename, filterFunc)
+	return err
+}
+
+// ExportSeq2ToParquetWithFilterAndStats exports filtered log entries and returns the number of rows written.
+func ExportSeq2ToParquetWithFilterAndStats(seq iter.Seq2[*LogEntry, error], filename string, filterFunc func(*LogEntry) bool) (int, error) {
 	file, err := os.Create(filename) //nolint:gosec // caller-controlled path
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _ = file.Close() }()
 
-	writer, err := NewParquetWriter(file)
+	return ExportSeq2ToParquetWriterWithFilter(seq, file, filterFunc)
+}
+
+// ExportSeq2ToParquetWriter exports log entries to any io.Writer.
+func ExportSeq2ToParquetWriter(seq iter.Seq2[*LogEntry, error], w io.Writer) (int, error) {
+	return ExportSeq2ToParquetWriterWithFilter(seq, w, nil)
+}
+
+// ExportSeq2ToParquetWriterWithFilter exports filtered log entries to any io.Writer.
+func ExportSeq2ToParquetWriterWithFilter(seq iter.Seq2[*LogEntry, error], w io.Writer, filterFunc func(*LogEntry) bool) (int, error) {
+	writer, err := NewParquetWriterForWriter(w)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer func() { _ = writer.Close() }()
 
 	const batchSize = 1000
 	batch := make([]*LogEntry, 0, batchSize)
+	rows := 0
 
 	for entry, err := range seq {
 		if err != nil {
-			return fmt.Errorf("error during iteration: %w", err)
+			return rows, fmt.Errorf("error during iteration: %w", err)
 		}
 
 		if filterFunc != nil && !filterFunc(entry) {
@@ -171,10 +193,11 @@ func ExportSeq2ToParquetWithFilter(seq iter.Seq2[*LogEntry, error], filename str
 		}
 
 		batch = append(batch, entry)
+		rows++
 
 		if len(batch) >= batchSize {
 			if err := writer.WriteBatch(batch); err != nil {
-				return err
+				return rows, err
 			}
 			batch = batch[:0]
 		}
@@ -182,9 +205,9 @@ func ExportSeq2ToParquetWithFilter(seq iter.Seq2[*LogEntry, error], filename str
 
 	if len(batch) > 0 {
 		if err := writer.WriteBatch(batch); err != nil {
-			return err
+			return rows, err
 		}
 	}
 
-	return nil
+	return rows, nil
 }

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -1,6 +1,7 @@
 package buildkitelogs
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -258,6 +259,24 @@ func TestParquetSeq2Export(t *testing.T) {
 	}
 	if results[2].Content != "Some regular output" {
 		t.Errorf("Entry 2 content = %q", results[2].Content)
+	}
+}
+
+func TestParquetSeq2ExportWriter(t *testing.T) {
+	parser := NewParser()
+	testData := "\x1b_bk;t=1745322209921\x07first line\n" +
+		"\x1b_bk;t=1745322209922\x07second line"
+
+	var buf bytes.Buffer
+	rows, err := ExportSeq2ToParquetWriter(parser.All(strings.NewReader(testData)), &buf)
+	if err != nil {
+		t.Fatalf("ExportSeq2ToParquetWriter() error = %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("rows = %d, want 2", rows)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected parquet bytes to be written")
 	}
 }
 


### PR DESCRIPTION
- Add per-job singleflight coalescing around durable cache generation to reduce duplicate Buildkite downloads, parquet generation, and blob writes for concurrent requests.
- Stream Buildkite log and parquet/blob storage paths to avoid full `os.ReadFile` buffering in the hot cache path.
- Add first-class hook metadata for stage, success, and errors, plus richer blob metadata for generated cache artifacts.
- Add regression coverage for concurrent refreshes, cache-hit status skipping, streaming blob writes, streaming log download, and hook error reporting.
