### PR TITLE
feat: allow configuring client parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ type logparser.Entry struct {
 ```go
 import "github.com/buildkite/buildkite-logs/logparser"
 
-parser := logparser.New(logparser.DefaultOptions())
+parser := logparser.New()
 for entry, err := range parser.All(reader) {
     // entry is a *logparser.Entry
 }

--- a/client.go
+++ b/client.go
@@ -34,6 +34,13 @@ func WithMaxLogBytes(n int64) ClientOption {
 	}
 }
 
+// WithParserOptions sets parser options used when converting downloaded logs to Parquet.
+func WithParserOptions(options ...logparser.Option) ClientOption {
+	return func(c *Client) {
+		c.parserOptions = append([]logparser.Option(nil), options...)
+	}
+}
+
 // Hook function types for different stages of downloadAndCacheWithBlobStorage
 type AfterCacheCheckFunc func(ctx context.Context, result *CacheCheckResult)
 type AfterJobStatusFunc func(ctx context.Context, result *JobStatusResult)
@@ -142,14 +149,15 @@ func (h *Hooks) AddAfterLocalCache(hook AfterLocalCacheFunc) {
 
 // Client provides a high-level convenience API for common buildkite-logs-parquet operations
 type Client struct {
-	api          BuildkiteAPI
-	storageURL   string
-	blobStorage  *BlobStorage
-	hooks        *Hooks
-	maxLogBytes  int64 // 0 means no limit
-	refreshGroup singleflight.Group
-	statusGroup  singleflight.Group
-	statusCache  sync.Map // map[string]statusCacheEntry
+	api           BuildkiteAPI
+	storageURL    string
+	blobStorage   *BlobStorage
+	hooks         *Hooks
+	maxLogBytes   int64 // 0 means no limit
+	refreshGroup  singleflight.Group
+	statusGroup   singleflight.Group
+	statusCache   sync.Map // map[string]statusCacheEntry
+	parserOptions []logparser.Option
 }
 
 type statusCacheEntry struct {
@@ -184,6 +192,12 @@ func NewClientWithAPI(ctx context.Context, api BuildkiteAPI, storageURL string, 
 	}
 
 	return c, nil
+}
+
+func (c *Client) newDefaultClientParser() *logparser.Parser {
+	return logparser.New(append([]logparser.Option{
+		logparser.WithTruncateLongLines(true),
+	}, c.parserOptions...)...)
 }
 
 // NewReader downloads and caches job logs (if needed) and returns a ParquetReader for querying.
@@ -404,7 +418,6 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 	}
 
 	logParsingStart := time.Now()
-	parser := logparser.New(defaultClientParserOptions())
 	tempFile, err := os.CreateTemp("", "bklog-*.parquet")
 	if err != nil {
 		logParsingDuration := time.Since(logParsingStart)
@@ -421,6 +434,7 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 		_ = os.Remove(tempPath)
 	}()
 
+	parser := c.newDefaultClientParser()
 	logEntries, err := ExportSeq2ToParquetWithFilterAndStats(parser.All(logReader), tempPath, nil)
 	logParsingDuration := time.Since(logParsingStart)
 	if err != nil {
@@ -477,12 +491,6 @@ func (c *Client) refreshBlobCache(ctx context.Context, api BuildkiteAPI, org, pi
 	}
 
 	return nil
-}
-
-func defaultClientParserOptions() logparser.Options {
-	options := logparser.DefaultOptions()
-	options.TruncateLongLines = true
-	return options
 }
 
 func (c *Client) createLocalCacheFileWithHooks(ctx context.Context, org, pipeline, build, job, blobKey string) (string, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -10,15 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildkite/buildkite-logs/logparser"
 	"github.com/buildkite/go-buildkite/v5"
 )
-
-func TestDefaultClientParserOptionsTruncateLongLines(t *testing.T) {
-	options := defaultClientParserOptions()
-	if !options.TruncateLongLines {
-		t.Fatal("client parser options should truncate long lines to avoid aborting ingestion")
-	}
-}
 
 // mockBuildkiteAPI implements BuildkiteAPI for testing with call tracking
 type mockBuildkiteAPI struct {
@@ -105,7 +99,10 @@ func TestClient_NewClient(t *testing.T) {
 	tempDir := t.TempDir()
 	storageURL := "file://" + tempDir
 
-	c, err := NewClient(t.Context(), client, storageURL)
+	c, err := NewClient(t.Context(), client, storageURL, WithParserOptions(
+		logparser.WithMaxLineBytes(12),
+		logparser.WithTruncationSuffix("[cut]"),
+	))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -114,15 +111,52 @@ func TestClient_NewClient(t *testing.T) {
 	if c.storageURL != storageURL {
 		t.Errorf("storageURL = %q, want %q", c.storageURL, storageURL)
 	}
+	entries, err := parseWithClientParser(c, "0123456789abcdef\n")
+	if err != nil {
+		t.Fatalf("client parser error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("client parser entries = %d, want 1", len(entries))
+	}
+	if got := entries[0].Content; got != "0123456[cut]" {
+		t.Fatalf("client parser content = %q, want %q", got, "0123456[cut]")
+	}
 }
 
 func TestClient_NewClientWithAPI(t *testing.T) {
 	mock := newTerminalMock()
-	client := newTestClient(t, mock)
+	client := newTestClient(t, mock, WithParserOptions(
+		logparser.WithMaxLineBytes(12),
+		logparser.WithTruncateLongLines(false),
+	))
 
 	if client.api != mock {
 		t.Error("api not set to mock")
 	}
+	if _, err := parseWithClientParser(client, "0123456789abcdef\n"); err == nil {
+		t.Fatal("expected client parser to reject long lines when truncation is disabled")
+	}
+}
+
+func TestClient_WithParserOptionsAcceptsNilOption(t *testing.T) {
+	mock := newTerminalMock()
+	client := newTestClient(t, mock, WithParserOptions(nil))
+
+	if _, err := parseWithClientParser(client, "0123456789abcdef\n"); err != nil {
+		t.Fatalf("nil parser option should keep a usable parser: %v", err)
+	}
+}
+
+func parseWithClientParser(client *Client, input string) ([]*logparser.Entry, error) {
+	parser := client.newDefaultClientParser()
+	var entries []*logparser.Entry
+	for entry, err := range parser.All(strings.NewReader(input)) {
+		if err != nil {
+			return entries, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
 }
 
 func TestClient_NewReader_Validation(t *testing.T) {

--- a/cmd/bklog/debug_cli.go
+++ b/cmd/bklog/debug_cli.go
@@ -98,7 +98,10 @@ func runDebug(config *DebugConfig) error {
 	}
 
 	parserOptions := debugParserOptions(config)
-	parser := logparser.New(parserOptions)
+	parser := logparser.New(
+		logparser.WithMaxLineBytes(parserOptions.MaxLineBytes),
+		logparser.WithTruncateLongLines(parserOptions.TruncateLongLines),
+	)
 	lineReader := logparser.NewLineReader(file, parserOptions)
 	processed := 0
 

--- a/cmd/bklog/debug_cli.go
+++ b/cmd/bklog/debug_cli.go
@@ -98,11 +98,8 @@ func runDebug(config *DebugConfig) error {
 	}
 
 	parserOptions := debugParserOptions(config)
-	parser := logparser.New(
-		logparser.WithMaxLineBytes(parserOptions.MaxLineBytes),
-		logparser.WithTruncateLongLines(parserOptions.TruncateLongLines),
-	)
-	lineReader := logparser.NewLineReader(file, parserOptions)
+	parser := logparser.New(parserOptions...)
+	lineReader := logparser.NewLineReader(file, parserOptions...)
 	processed := 0
 
 	// Calculate end line
@@ -169,11 +166,11 @@ func runDebug(config *DebugConfig) error {
 	return nil
 }
 
-func debugParserOptions(config *DebugConfig) logparser.Options {
-	options := logparser.DefaultOptions()
-	options.MaxLineBytes = config.MaxLineBytes
-	options.TruncateLongLines = config.TruncateLongLines
-	return options
+func debugParserOptions(config *DebugConfig) []logparser.Option {
+	return []logparser.Option{
+		logparser.WithMaxLineBytes(config.MaxLineBytes),
+		logparser.WithTruncateLongLines(config.TruncateLongLines),
+	}
 }
 
 // extractTimestampsToCSV extracts all OSC timestamps from the log file and exports to CSV
@@ -198,7 +195,7 @@ func extractTimestampsToCSV(config *DebugConfig) error {
 		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
-	lineReader := logparser.NewLineReader(file, debugParserOptions(config))
+	lineReader := logparser.NewLineReader(file, debugParserOptions(config)...)
 	totalTimestamps := 0
 
 	for {

--- a/cmd/bklog/parse_cli.go
+++ b/cmd/bklog/parse_cli.go
@@ -135,10 +135,10 @@ func runParse(ctx context.Context, config *Config) error {
 		BytesProcessed: bytesProcessed,
 	}
 
-	parserOptions := logparser.DefaultOptions()
-	parserOptions.MaxLineBytes = config.MaxLineBytes
-	parserOptions.TruncateLongLines = config.TruncateLongLines
-	parser := logparser.New(parserOptions)
+	parser := logparser.New(
+		logparser.WithMaxLineBytes(config.MaxLineBytes),
+		logparser.WithTruncateLongLines(config.TruncateLongLines),
+	)
 
 	// Handle export options
 	switch {

--- a/group_test.go
+++ b/group_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGroupTracking(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := []string{
 		"\x1b_bk;t=1745322209921\x07~~~ Running global environment hook",
@@ -43,7 +43,7 @@ func TestGroupTracking(t *testing.T) {
 }
 
 func TestGroupTrackingWithIterator(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := `~~~ Running global environment hook
 [90m$[0m /buildkite/agent/hooks/environment
@@ -85,7 +85,7 @@ Test output line`
 }
 
 func TestGroupTrackingMalformedTimestamp(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=invalid\x07~~~ Setup phase\n" +
 		"\x1b_bk;t=1745322209922\x07some output"

--- a/iter_test.go
+++ b/iter_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIterSeq2(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +
@@ -49,7 +49,7 @@ func TestIterSeq2(t *testing.T) {
 }
 
 func TestIterSeq2EarlyExit(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +
@@ -82,7 +82,7 @@ func TestIterSeq2EarlyExit(t *testing.T) {
 }
 
 func TestIterSeq2GroupTracking(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +
@@ -117,7 +117,7 @@ func TestIterSeq2GroupTracking(t *testing.T) {
 }
 
 func TestIterSeq2WithFiltering(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +
@@ -157,7 +157,7 @@ func TestIterSeq2WithFiltering(t *testing.T) {
 }
 
 func TestAllScannerError(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	reader := iotest.ErrReader(fmt.Errorf("disk read failure"))
 
 	var gotErr error

--- a/logparser/fuzz_test.go
+++ b/logparser/fuzz_test.go
@@ -27,10 +27,10 @@ func FuzzParseLine(f *testing.F) {
 			t.Skip("keep fuzz cases bounded")
 		}
 
-		parser := New(Options{
-			MaxLineBytes: 4096,
-			ContextBytes: 32,
-		})
+		parser := New(
+			WithMaxLineBytes(4096),
+			WithContextBytes(32),
+		)
 		entry, err := parser.ParseLine(input)
 		if err != nil {
 			assertParseErrorBounds(t, err, len(input), 32)
@@ -110,11 +110,11 @@ func FuzzParserAll(f *testing.F) {
 			t.Skip("keep fuzz cases bounded")
 		}
 
-		parser := New(Options{
-			MaxLineBytes:      4096,
-			TruncateLongLines: true,
-			ContextBytes:      32,
-		})
+		parser := New(
+			WithMaxLineBytes(4096),
+			WithTruncateLongLines(true),
+			WithContextBytes(32),
+		)
 		for entry, err := range parser.All(strings.NewReader(input)) {
 			if err != nil {
 				assertParseErrorBounds(t, err, len(input), 32)

--- a/logparser/fuzz_test.go
+++ b/logparser/fuzz_test.go
@@ -63,12 +63,13 @@ func FuzzLineReader(f *testing.F) {
 			t.Skip("keep fuzz cases bounded")
 		}
 
-		reader := NewLineReader(strings.NewReader(input), Options{
-			MaxLineBytes:      4096,
-			TruncateLongLines: true,
-			TruncationSuffix:  "[truncated]",
-			ContextBytes:      32,
-		})
+		reader := NewLineReader(
+			strings.NewReader(input),
+			WithMaxLineBytes(4096),
+			WithTruncateLongLines(true),
+			WithTruncationSuffix("[truncated]"),
+			WithContextBytes(32),
+		)
 
 		for {
 			line, err := reader.Next()

--- a/logparser/options.go
+++ b/logparser/options.go
@@ -27,10 +27,6 @@ func (f optionFunc) apply(opts *Options) {
 	f(opts)
 }
 
-func (opts Options) apply(target *Options) {
-	*target = opts
-}
-
 // DefaultOptions returns conservative defaults for preserving log data while
 // supporting lines that exceed bufio.Scanner's token limit.
 func DefaultOptions() Options {
@@ -42,30 +38,36 @@ func DefaultOptions() Options {
 	}
 }
 
+// WithBufferSize sets the buffered reader size used while reading log lines.
 func WithBufferSize(size int) Option {
 	return optionFunc(func(opts *Options) {
 		opts.BufferSize = size
 	})
 }
 
+// WithMaxLineBytes sets the maximum bytes allowed for a single log line.
 func WithMaxLineBytes(size int) Option {
 	return optionFunc(func(opts *Options) {
 		opts.MaxLineBytes = size
 	})
 }
 
+// WithTruncateLongLines controls whether over-limit log lines are truncated
+// instead of returned as line-too-long parse errors.
 func WithTruncateLongLines(truncate bool) Option {
 	return optionFunc(func(opts *Options) {
 		opts.TruncateLongLines = truncate
 	})
 }
 
+// WithTruncationSuffix sets the suffix appended to truncated log lines.
 func WithTruncationSuffix(suffix string) Option {
 	return optionFunc(func(opts *Options) {
 		opts.TruncationSuffix = suffix
 	})
 }
 
+// WithContextBytes sets how many nearby bytes are captured in parse errors.
 func WithContextBytes(size int) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ContextBytes = size

--- a/logparser/options.go
+++ b/logparser/options.go
@@ -16,6 +16,21 @@ type Options struct {
 	ContextBytes      int
 }
 
+// Option customizes parser behavior.
+type Option interface {
+	apply(*Options)
+}
+
+type optionFunc func(*Options)
+
+func (f optionFunc) apply(opts *Options) {
+	f(opts)
+}
+
+func (opts Options) apply(target *Options) {
+	*target = opts
+}
+
 // DefaultOptions returns conservative defaults for preserving log data while
 // supporting lines that exceed bufio.Scanner's token limit.
 func DefaultOptions() Options {
@@ -25,6 +40,36 @@ func DefaultOptions() Options {
 		TruncationSuffix: DefaultTruncationSuffix,
 		ContextBytes:     DefaultContextBytes,
 	}
+}
+
+func WithBufferSize(size int) Option {
+	return optionFunc(func(opts *Options) {
+		opts.BufferSize = size
+	})
+}
+
+func WithMaxLineBytes(size int) Option {
+	return optionFunc(func(opts *Options) {
+		opts.MaxLineBytes = size
+	})
+}
+
+func WithTruncateLongLines(truncate bool) Option {
+	return optionFunc(func(opts *Options) {
+		opts.TruncateLongLines = truncate
+	})
+}
+
+func WithTruncationSuffix(suffix string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.TruncationSuffix = suffix
+	})
+}
+
+func WithContextBytes(size int) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ContextBytes = size
+	})
 }
 
 func normalizeOptions(opts Options) Options {

--- a/logparser/options.go
+++ b/logparser/options.go
@@ -38,6 +38,16 @@ func DefaultOptions() Options {
 	}
 }
 
+func optionsFrom(options ...Option) Options {
+	opts := DefaultOptions()
+	for _, option := range options {
+		if option != nil {
+			option.apply(&opts)
+		}
+	}
+	return normalizeOptions(opts)
+}
+
 // WithBufferSize sets the buffered reader size used while reading log lines.
 func WithBufferSize(size int) Option {
 	return optionFunc(func(opts *Options) {

--- a/logparser/parser.go
+++ b/logparser/parser.go
@@ -18,14 +18,7 @@ type Parser struct {
 }
 
 func New(options ...Option) *Parser {
-	opts := DefaultOptions()
-	for _, option := range options {
-		if option != nil {
-			option.apply(&opts)
-		}
-	}
-
-	return newParserWithOptions(opts)
+	return newParserWithOptions(optionsFrom(options...))
 }
 
 func newParserWithOptions(opts Options) *Parser {
@@ -61,7 +54,7 @@ func (p *Parser) ParseLineBytes(line []byte, meta Line) (*Entry, error) {
 func (p *Parser) All(reader io.Reader) iter.Seq2[*Entry, error] {
 	return func(yield func(*Entry, error) bool) {
 		localParser := newParserWithOptions(p.opts)
-		lineReader := NewLineReader(reader, p.opts)
+		lineReader := newLineReaderWithOptions(reader, p.opts)
 
 		for {
 			line, err := lineReader.Next()

--- a/logparser/parser.go
+++ b/logparser/parser.go
@@ -25,6 +25,10 @@ func New(options ...Option) *Parser {
 		}
 	}
 
+	return newParserWithOptions(opts)
+}
+
+func newParserWithOptions(opts Options) *Parser {
 	return &Parser{
 		opts: normalizeOptions(opts),
 	}
@@ -56,7 +60,7 @@ func (p *Parser) ParseLineBytes(line []byte, meta Line) (*Entry, error) {
 // isolated group state so a parser can be reused safely.
 func (p *Parser) All(reader io.Reader) iter.Seq2[*Entry, error] {
 	return func(yield func(*Entry, error) bool) {
-		localParser := New(p.opts)
+		localParser := newParserWithOptions(p.opts)
 		lineReader := NewLineReader(reader, p.opts)
 
 		for {

--- a/logparser/parser.go
+++ b/logparser/parser.go
@@ -17,7 +17,14 @@ type Parser struct {
 	currentGroup string
 }
 
-func New(opts Options) *Parser {
+func New(options ...Option) *Parser {
+	opts := DefaultOptions()
+	for _, option := range options {
+		if option != nil {
+			option.apply(&opts)
+		}
+	}
+
 	return &Parser{
 		opts: normalizeOptions(opts),
 	}

--- a/logparser/parser_test.go
+++ b/logparser/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAllHandlesLinesOverOneMiB(t *testing.T) {
-	parser := New(DefaultOptions())
+	parser := New()
 	content := strings.Repeat("a", 1024*1024+128)
 	input := "\x1b_bk;t=1745322209921\x07" + content
 
@@ -107,7 +107,7 @@ func TestNewWithFunctionalOptions(t *testing.T) {
 }
 
 func TestParserUnterminatedOSCTreatedAsPlainContent(t *testing.T) {
-	parser := New(Options{ContextBytes: 3})
+	parser := New(WithContextBytes(3))
 	input := "\x1b_bk;t=123456"
 	entry, err := parser.ParseLine(input)
 	if err != nil {

--- a/logparser/parser_test.go
+++ b/logparser/parser_test.go
@@ -83,6 +83,29 @@ func TestLineReaderTruncatesLongLine(t *testing.T) {
 	}
 }
 
+func TestNewWithFunctionalOptions(t *testing.T) {
+	parser := New(
+		WithMaxLineBytes(12),
+		WithTruncateLongLines(true),
+		WithTruncationSuffix("[cut]"),
+	)
+
+	var entries []*Entry
+	for entry, err := range parser.All(strings.NewReader("0123456789abcdef\n")) {
+		if err != nil {
+			t.Fatalf("All() error = %v", err)
+		}
+		entries = append(entries, entry)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	if got := entries[0].Content; got != "0123456[cut]" {
+		t.Fatalf("content = %q, want %q", got, "0123456[cut]")
+	}
+}
+
 func TestParserUnterminatedOSCTreatedAsPlainContent(t *testing.T) {
 	parser := New(Options{ContextBytes: 3})
 	input := "\x1b_bk;t=123456"

--- a/logparser/parser_test.go
+++ b/logparser/parser_test.go
@@ -33,10 +33,11 @@ func TestAllHandlesLinesOverOneMiB(t *testing.T) {
 }
 
 func TestLineReaderHardErrorsOnLongLine(t *testing.T) {
-	reader := NewLineReader(strings.NewReader("0123456789abcdef\nnext"), Options{
-		MaxLineBytes: 8,
-		ContextBytes: 4,
-	})
+	reader := NewLineReader(
+		strings.NewReader("0123456789abcdef\nnext"),
+		WithMaxLineBytes(8),
+		WithContextBytes(4),
+	)
 
 	_, err := reader.Next()
 	if err == nil {
@@ -62,11 +63,12 @@ func TestLineReaderHardErrorsOnLongLine(t *testing.T) {
 }
 
 func TestLineReaderTruncatesLongLine(t *testing.T) {
-	reader := NewLineReader(strings.NewReader("0123456789abcdef\n"), Options{
-		MaxLineBytes:      12,
-		TruncateLongLines: true,
-		TruncationSuffix:  "[cut]",
-	})
+	reader := NewLineReader(
+		strings.NewReader("0123456789abcdef\n"),
+		WithMaxLineBytes(12),
+		WithTruncateLongLines(true),
+		WithTruncationSuffix("[cut]"),
+	)
 
 	line, err := reader.Next()
 	if err != nil {
@@ -125,10 +127,11 @@ func TestParserUnterminatedOSCTreatedAsPlainContent(t *testing.T) {
 }
 
 func TestParseErrorStringOmitsContextBytes(t *testing.T) {
-	reader := NewLineReader(strings.NewReader("prefix_SECRET_TOKEN_123_suffix\n"), Options{
-		MaxLineBytes: 8,
-		ContextBytes: 32,
-	})
+	reader := NewLineReader(
+		strings.NewReader("prefix_SECRET_TOKEN_123_suffix\n"),
+		WithMaxLineBytes(8),
+		WithContextBytes(32),
+	)
 	_, err := reader.Next()
 	if err == nil {
 		t.Fatal("expected line-too-long error")
@@ -155,10 +158,11 @@ func TestParseErrorStringOmitsContextBytes(t *testing.T) {
 }
 
 func TestParseErrorAllowsZeroContextBytes(t *testing.T) {
-	reader := NewLineReader(strings.NewReader("prefix_SECRET_TOKEN_123_suffix\n"), Options{
-		MaxLineBytes: 8,
-		ContextBytes: 0,
-	})
+	reader := NewLineReader(
+		strings.NewReader("prefix_SECRET_TOKEN_123_suffix\n"),
+		WithMaxLineBytes(8),
+		WithContextBytes(0),
+	)
 	_, err := reader.Next()
 	if err == nil {
 		t.Fatal("expected line-too-long error")
@@ -174,7 +178,7 @@ func TestParseErrorAllowsZeroContextBytes(t *testing.T) {
 }
 
 func TestLineReaderNoFinalNewline(t *testing.T) {
-	reader := NewLineReader(strings.NewReader("first\nsecond"), DefaultOptions())
+	reader := NewLineReader(strings.NewReader("first\nsecond"))
 
 	line, err := reader.Next()
 	if err != nil {

--- a/logparser/reader.go
+++ b/logparser/reader.go
@@ -24,8 +24,11 @@ type LineReader struct {
 	offset int64
 }
 
-func NewLineReader(r io.Reader, opts Options) *LineReader {
-	opts = normalizeOptions(opts)
+func NewLineReader(r io.Reader, options ...Option) *LineReader {
+	return newLineReaderWithOptions(r, optionsFrom(options...))
+}
+
+func newLineReaderWithOptions(r io.Reader, opts Options) *LineReader {
 	return &LineReader{
 		reader: bufio.NewReaderSize(r, opts.BufferSize),
 		opts:   opts,

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -233,7 +233,7 @@ func TestParquetRoundtripRowNumbers(t *testing.T) {
 }
 
 func TestParquetSeq2Export(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +
@@ -265,7 +265,7 @@ func TestParquetSeq2Export(t *testing.T) {
 }
 
 func TestParquetSeq2ExportWriter(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	testData := "\x1b_bk;t=1745322209921\x07first line\n" +
 		"\x1b_bk;t=1745322209922\x07second line"
 
@@ -283,7 +283,7 @@ func TestParquetSeq2ExportWriter(t *testing.T) {
 }
 
 func TestParquetSeq2ExportWithFilter(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testData := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209922\x07$ /buildkite/agent/hooks/environment\n" +

--- a/parser_bench_test.go
+++ b/parser_bench_test.go
@@ -59,7 +59,7 @@ func generateTestData(numLines int) string {
 
 // BenchmarkParseLine tests the performance of parsing individual lines
 func BenchmarkParseLine(b *testing.B) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	line := "\x1b_bk;t=1745322209921\x07[90m$[0m /buildkite/agent/hooks/environment"
 
 	b.ResetTimer()
@@ -73,7 +73,7 @@ func BenchmarkParseLine(b *testing.B) {
 
 // BenchmarkParseLineNoTimestamp tests parsing lines without OSC sequences
 func BenchmarkParseLineNoTimestamp(b *testing.B) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	line := "Regular log line without timestamp information"
 
 	b.ResetTimer()
@@ -92,7 +92,7 @@ func BenchmarkIterator(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("lines_%d", size), func(b *testing.B) {
 			data := generateTestData(size)
-			parser := logparser.New(logparser.DefaultOptions())
+			parser := logparser.New()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -116,7 +116,7 @@ func BenchmarkIterator(b *testing.B) {
 // BenchmarkIteratorWithFiltering tests iterator performance with filtering
 func BenchmarkIteratorWithFiltering(b *testing.B) {
 	data := generateTestData(10000)
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	filters := []struct {
 		name string
@@ -149,7 +149,7 @@ func BenchmarkIteratorWithFiltering(b *testing.B) {
 // BenchmarkMemoryUsage provides a rough comparison of memory allocation patterns
 func BenchmarkMemoryUsage(b *testing.B) {
 	data := generateTestData(10000)
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	b.Run("iterator", func(b *testing.B) {
 		b.ResetTimer()
@@ -193,7 +193,7 @@ func BenchmarkSeq2Iterator(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("lines_%d", size), func(b *testing.B) {
 			data := generateTestData(size)
-			parser := logparser.New(logparser.DefaultOptions())
+			parser := logparser.New()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -223,7 +223,7 @@ func BenchmarkParquetSeq2Export(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("lines_%d", size), func(b *testing.B) {
 			data := generateTestData(size)
-			parser := logparser.New(logparser.DefaultOptions())
+			parser := logparser.New()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -244,7 +244,7 @@ func BenchmarkParquetSeq2Export(b *testing.B) {
 
 // BenchmarkParseLineCore tests the core parse performance
 func BenchmarkParseLineCore(b *testing.B) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	testCases := []struct {
 		name string
@@ -271,7 +271,7 @@ func BenchmarkParseLineCore(b *testing.B) {
 // BenchmarkContentClassification tests entry classification performance
 func BenchmarkContentClassification(b *testing.B) {
 	data := generateTestData(1000)
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	reader := strings.NewReader(data)
 
 	// Pre-parse entries

--- a/parser_test.go
+++ b/parser_test.go
@@ -12,7 +12,7 @@ import (
 // group tracking on top of ByteParser.ParseLine). For byte-level parsing tests,
 // see TestByteParserBasic in scanner_test.go.
 func TestParseLine(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	tests := []struct {
 		name        string
@@ -88,7 +88,7 @@ func TestParseLine(t *testing.T) {
 }
 
 func TestLogEntryClassification(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	tests := []struct {
 		name      string
@@ -133,7 +133,7 @@ func TestLogEntryClassification(t *testing.T) {
 }
 
 func TestParseReader(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	input := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209921\x07[90m$[0m /buildkite/agent/hooks/environment\n" +
@@ -186,7 +186,7 @@ func TestParseReader(t *testing.T) {
 }
 
 func TestParserAllCompatibility(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	input := "\x1b_bk;t=1745322209921\x07~~~ Running global environment hook\n" +
 		"\x1b_bk;t=1745322209921\x07[90m$[0m /buildkite/agent/hooks/environment\n" +
@@ -242,7 +242,7 @@ func TestParserAllCompatibility(t *testing.T) {
 }
 
 func TestLogIteratorEmpty(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	reader := strings.NewReader("")
 
 	for range parser.All(reader) {
@@ -251,7 +251,7 @@ func TestLogIteratorEmpty(t *testing.T) {
 }
 
 func TestLogIteratorInvalidTimestamp(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	// An overflowing timestamp in valid OSC framing should not cause an error;
 	// the line is returned with a zero timestamp and the OSC envelope stripped.
@@ -312,7 +312,7 @@ func TestComputeFlags(t *testing.T) {
 		},
 	}
 
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			entry, err := parser.ParseLine(tt.input)
@@ -333,7 +333,7 @@ func TestComputeFlags(t *testing.T) {
 }
 
 func TestParseLineEdgeCases(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	inputs := []string{
 		"",
@@ -355,7 +355,7 @@ func TestParseLineEdgeCases(t *testing.T) {
 }
 
 func TestParseLineMultiOSCTruncation(t *testing.T) {
-	parser := logparser.New(logparser.DefaultOptions())
+	parser := logparser.New()
 
 	input := "\x1b_bk;t=1745322209921\x07first content\x1b_bk;t=1745322209922\x07second content"
 	entry, err := parser.ParseLine(input)


### PR DESCRIPTION
- Add functional options for `logparser.New` and `logparser.NewLineReader`.
- Add `WithParserOptions` to the high-level client so consumers can tune parser behavior while preserving the client default of truncating long lines.
- Update parser, line reader, CLI, tests, fuzzers, and docs to use the functional options API.