### PR TITLE
fix: validate access after shared log refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,14 @@ type BuildkiteAPI interface {
 }
 ```
 
-`JobLogExists` is an authorization boundary for cached logs. It must check the
-log endpoint using the current caller's API identity without downloading the
-log body. Return `false, nil` when the log does not exist; return an error when
-the access check fails. The client checks this method before every cached read
-and fails closed rather than serving cached content. A false result is returned
-as `ErrJobLogUnavailable`, which intentionally does not distinguish a missing
-log from an inaccessible one.
+`JobLogExists` is the authorization boundary for all log reads. It must check
+the log endpoint using the current caller's API identity without downloading
+the log body. Return `false, nil` when the log does not exist; return an error
+when the access check fails. The client calls this method before every request,
+including cold cache misses and force refreshes, and fails closed before using
+or joining shared cache work. A false result is returned as
+`ErrJobLogUnavailable`, which intentionally does not distinguish a missing log
+from an inaccessible one.
 
 Adding `JobLogExists` is an intentional source-breaking change for custom API
 implementations during the library's `0.x` development. The official adapter
@@ -817,15 +818,15 @@ The library uses a two-tier intelligent caching strategy that optimizes for both
 
 ```mermaid
 flowchart TD
-    A[Start: DownloadAndCache] --> B[Check blob storage cache]
+    A[Start: DownloadAndCache] --> E[HEAD log with JobLogExists]
+    E --> F{Current identity<br/>can access log?}
+    F -->|No| X[Return access error]
+    F -->|Yes| B[Check blob storage cache]
     B --> C{Cache exists?}
     C -->|No| H[Get job status and download logs]
     C -->|Yes| D{Force refresh?}
     D -->|Yes| H
-    D -->|No| E[HEAD log with JobLogExists]
-    E --> F{Current identity<br/>can access log?}
-    F -->|No| X[Return access error]
-    F -->|Yes| G{Cached metadata<br/>is terminal?}
+    D -->|No| G{Cached metadata<br/>is terminal?}
     G -->|Yes| T[Use permanent cache]
     G -->|No| I{Time elapsed < TTL?}
     I -->|No| H
@@ -853,11 +854,11 @@ flowchart TD
 ```
 
 **Caching Strategy:**
-- **Authorization**: Every cached read first calls `JobLogExists` using the current API identity. Missing, inaccessible, or failed checks never serve cached content.
-- **Terminal Jobs**: Once a job completes, logs never change, so cache them without a TTL or status lookup. Authorization is still checked on every read.
+- **Authorization**: Every request first calls `JobLogExists` using the current API identity, including cold cache misses and force refreshes. Missing, inaccessible, or failed checks cannot use or join shared cache work.
+- **Terminal Jobs**: Once a job completes, logs never change, so cache them without a TTL or status lookup. Authorization is still checked on every request.
 - **Running Jobs Within TTL**: Call `GetJobStatus` to detect a terminal transition immediately; otherwise use the cached log.
 - **Running Jobs After TTL**: Refresh the log and persist its latest terminal state. Concurrent refreshes are coalesced.
-- **Force Refresh**: Override cache entirely for debugging or manual refresh scenarios
+- **Force Refresh**: Override cached content after the caller passes the same authorization check
 
 ### Benefits of Parquet Format
 

--- a/client.go
+++ b/client.go
@@ -261,6 +261,11 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		ttl = 30 * time.Second // Default TTL
 	}
 
+	// Authorize every caller before it can use or join shared cache work.
+	if err := validateJobLogAccess(ctx, api, org, pipeline, build, job); err != nil {
+		return "", fmt.Errorf("failed to validate job log access: %w", err)
+	}
+
 	blobKey := GenerateBlobKey(org, pipeline, build, job)
 
 	cacheCheckStart := time.Now()
@@ -272,19 +277,15 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 	}
 
 	var jobStatus *JobStatus
-	cacheChecked := false
-	accessValidated := false
 	if exists && !forceRefresh {
 		var usable bool
-		jobStatus, usable, err = c.checkCachedJobLog(ctx, api, org, pipeline, build, job, blobKey, ttl)
+		jobStatus, usable, err = c.checkCachedJobLog(ctx, api, org, pipeline, build, job, blobKey, ttl, nil)
 		if err != nil {
-			return "", fmt.Errorf("failed to validate cached job log access: %w", err)
+			return "", fmt.Errorf("failed to check cached job log: %w", err)
 		}
-		accessValidated = true
 		if usable {
 			return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 		}
-		cacheChecked = true
 	}
 
 	// Decouple shared refresh work from the single caller that wins the
@@ -299,18 +300,9 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 			}
 			if exists {
 				var usable bool
-				if !cacheChecked {
-					jobStatus, usable, err = c.checkCachedJobLog(refreshCtx, api, org, pipeline, build, job, blobKey, ttl)
-					if err != nil {
-						return nil, fmt.Errorf("failed to validate cached job log access: %w", err)
-					}
-					accessValidated = true
-				} else {
-					metadata, err := c.blobStorage.ReadWithMetadata(refreshCtx, blobKey)
-					if err != nil {
-						return nil, fmt.Errorf("failed to recheck cached job log metadata: %w", err)
-					}
-					usable = cacheMetadataUsable(metadata, jobStatus, ttl)
+				jobStatus, usable, err = c.checkCachedJobLog(refreshCtx, api, org, pipeline, build, job, blobKey, ttl, jobStatus)
+				if err != nil {
+					return nil, fmt.Errorf("failed to recheck cached job log: %w", err)
 				}
 				if usable {
 					return nil, nil
@@ -329,38 +321,28 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		}
 	}
 
-	// The shared refresh may have run with another caller's API identity.
-	// Validate this caller independently before serving the refreshed blob.
-	if !accessValidated {
-		if err := validateJobLogAccess(ctx, api, org, pipeline, build, job); err != nil {
-			return "", fmt.Errorf("failed to validate refreshed job log access: %w", err)
-		}
-	}
-
 	return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 }
 
-func (c *Client) checkCachedJobLog(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job, blobKey string, ttl time.Duration) (*JobStatus, bool, error) {
-	if err := validateJobLogAccess(ctx, api, org, pipeline, build, job); err != nil {
-		return nil, false, err
-	}
-
+func (c *Client) checkCachedJobLog(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job, blobKey string, ttl time.Duration, status *JobStatus) (*JobStatus, bool, error) {
 	metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
 	if err != nil || metadata == nil {
-		return nil, false, err
+		return status, false, err
 	}
 	if metadata.IsTerminal {
-		return nil, true, nil
+		return status, true, nil
 	}
 	if time.Since(metadata.CachedAt) > ttl {
-		return nil, false, nil
+		return status, false, nil
 	}
 
-	status, err := c.getJobStatus(ctx, api, org, pipeline, build, job)
-	if err != nil {
-		return nil, false, err
+	if status == nil {
+		status, err = c.getJobStatus(ctx, api, org, pipeline, build, job)
+		if err != nil {
+			return nil, false, err
+		}
 	}
-	return status, cacheMetadataUsable(metadata, status, ttl), nil
+	return status, !status.IsTerminal, nil
 }
 
 func validateJobLogAccess(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string) error {
@@ -372,19 +354,6 @@ func validateJobLogAccess(ctx context.Context, api BuildkiteAPI, org, pipeline, 
 		return ErrJobLogUnavailable
 	}
 	return nil
-}
-
-func cacheMetadataUsable(metadata *BlobMetadata, status *JobStatus, ttl time.Duration) bool {
-	if metadata == nil {
-		return false
-	}
-	if metadata.IsTerminal {
-		return true
-	}
-	if time.Since(metadata.CachedAt) > ttl {
-		return false
-	}
-	return status == nil || !status.IsTerminal
 }
 
 func (c *Client) getJobStatus(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string) (*JobStatus, error) {

--- a/client.go
+++ b/client.go
@@ -273,12 +273,14 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 
 	var jobStatus *JobStatus
 	cacheChecked := false
+	accessValidated := false
 	if exists && !forceRefresh {
 		var usable bool
 		jobStatus, usable, err = c.checkCachedJobLog(ctx, api, org, pipeline, build, job, blobKey, ttl)
 		if err != nil {
 			return "", fmt.Errorf("failed to validate cached job log access: %w", err)
 		}
+		accessValidated = true
 		if usable {
 			return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 		}
@@ -302,6 +304,7 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 					if err != nil {
 						return nil, fmt.Errorf("failed to validate cached job log access: %w", err)
 					}
+					accessValidated = true
 				} else {
 					metadata, err := c.blobStorage.ReadWithMetadata(refreshCtx, blobKey)
 					if err != nil {
@@ -326,21 +329,25 @@ func (c *Client) downloadAndCacheWithBlobStorage(ctx context.Context, api Buildk
 		}
 	}
 
+	// The shared refresh may have run with another caller's API identity.
+	// Validate this caller independently before serving the refreshed blob.
+	if !accessValidated {
+		if err := validateJobLogAccess(ctx, api, org, pipeline, build, job); err != nil {
+			return "", fmt.Errorf("failed to validate refreshed job log access: %w", err)
+		}
+	}
+
 	return c.createLocalCacheFileWithHooks(ctx, org, pipeline, build, job, blobKey)
 }
 
 func (c *Client) checkCachedJobLog(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job, blobKey string, ttl time.Duration) (*JobStatus, bool, error) {
-	metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
-	if err != nil || metadata == nil {
+	if err := validateJobLogAccess(ctx, api, org, pipeline, build, job); err != nil {
 		return nil, false, err
 	}
 
-	exists, err := api.JobLogExists(ctx, org, pipeline, build, job)
-	if err != nil {
+	metadata, err := c.blobStorage.ReadWithMetadata(ctx, blobKey)
+	if err != nil || metadata == nil {
 		return nil, false, err
-	}
-	if !exists {
-		return nil, false, ErrJobLogUnavailable
 	}
 	if metadata.IsTerminal {
 		return nil, true, nil
@@ -354,6 +361,17 @@ func (c *Client) checkCachedJobLog(ctx context.Context, api BuildkiteAPI, org, p
 		return nil, false, err
 	}
 	return status, cacheMetadataUsable(metadata, status, ttl), nil
+}
+
+func validateJobLogAccess(ctx context.Context, api BuildkiteAPI, org, pipeline, build, job string) error {
+	exists, err := api.JobLogExists(ctx, org, pipeline, build, job)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrJobLogUnavailable
+	}
+	return nil
 }
 
 func cacheMetadataUsable(metadata *BlobMetadata, status *JobStatus, ttl time.Duration) bool {

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 var ErrLogTooLarge = errors.New("log exceeds maximum allowed size")
 
 // ErrJobLogUnavailable is returned when the current API identity cannot access
-// a cached job log. Buildkite may use a not-found response to conceal access.
+// a job log. Buildkite may use a not-found response to conceal access.
 var ErrJobLogUnavailable = errors.New("job log does not exist or is not accessible")
 
 // DefaultMaxLogBytes is the default maximum log size (10MB).

--- a/client_test.go
+++ b/client_test.go
@@ -394,7 +394,7 @@ func (a *requestScopedBuildkiteAPI) JobLogExists(ctx context.Context, org, pipel
 	return ctx.Value(requestIdentityKey{}) == "authorized", nil
 }
 
-func TestClient_ConcurrentCacheMiss_ValidatesWaiterIdentity(t *testing.T) {
+func TestClient_ConcurrentCacheMiss_RejectsUnauthorizedRequest(t *testing.T) {
 	mock := newTerminalMock()
 	mock.logDelay = 50 * time.Millisecond
 	mock.logStarted = make(chan struct{}, 1)
@@ -563,7 +563,7 @@ func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
 	}
 }
 
-func TestClient_ConcurrentForceRefresh_ValidatesWaiterIdentity(t *testing.T) {
+func TestClient_ConcurrentForceRefresh_RejectsUnauthorizedRequest(t *testing.T) {
 	mock := newTerminalMock()
 	api := &requestScopedBuildkiteAPI{mockBuildkiteAPI: mock}
 	client := newTestClient(t, api)

--- a/client_test.go
+++ b/client_test.go
@@ -102,10 +102,10 @@ func newTerminalMock() *mockBuildkiteAPI {
 	}
 }
 
-func newTestClient(t *testing.T, mock *mockBuildkiteAPI, opts ...ClientOption) *Client {
+func newTestClient(t *testing.T, api BuildkiteAPI, opts ...ClientOption) *Client {
 	t.Helper()
 	tempDir := t.TempDir()
-	client, err := NewClientWithAPI(t.Context(), mock, "file://"+tempDir, opts...)
+	client, err := NewClientWithAPI(t.Context(), api, "file://"+tempDir, opts...)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -251,8 +251,8 @@ func TestClient_NewReader_CacheHit(t *testing.T) {
 	if _, statusCalls := mock.calls(); statusCalls != 1 {
 		t.Errorf("GetJobStatus calls = %d, want 1", statusCalls)
 	}
-	if existsCalls := mock.existsCalls(); existsCalls != 1 {
-		t.Errorf("JobLogExists calls = %d, want 1", existsCalls)
+	if existsCalls := mock.existsCalls(); existsCalls != 2 {
+		t.Errorf("JobLogExists calls = %d, want 2", existsCalls)
 	}
 }
 
@@ -381,6 +381,49 @@ func TestClient_ConcurrentCacheMiss_SingleFlight(t *testing.T) {
 	}
 }
 
+type requestIdentityKey struct{}
+
+type requestScopedBuildkiteAPI struct {
+	*mockBuildkiteAPI
+}
+
+func (a *requestScopedBuildkiteAPI) JobLogExists(ctx context.Context, org, pipeline, build, job string) (bool, error) {
+	a.mu.Lock()
+	a.getExistsCalls++
+	a.mu.Unlock()
+	return ctx.Value(requestIdentityKey{}) == "authorized", nil
+}
+
+func TestClient_ConcurrentCacheMiss_ValidatesWaiterIdentity(t *testing.T) {
+	mock := newTerminalMock()
+	mock.logDelay = 50 * time.Millisecond
+	mock.logStarted = make(chan struct{}, 1)
+	client := newTestClient(t, &requestScopedBuildkiteAPI{mockBuildkiteAPI: mock})
+
+	authorizedCtx := context.WithValue(t.Context(), requestIdentityKey{}, "authorized")
+	unauthorizedCtx := context.WithValue(t.Context(), requestIdentityKey{}, "unauthorized")
+	leaderErr := make(chan error, 1)
+	go func() {
+		reader, err := client.NewReader(authorizedCtx, "org", "pipeline", "123", "job-1", time.Minute, false)
+		if reader != nil {
+			_ = reader.Close()
+		}
+		leaderErr <- err
+	}()
+
+	<-mock.logStarted
+	reader, err := client.NewReader(unauthorizedCtx, "org", "pipeline", "123", "job-1", time.Minute, false)
+	if reader != nil {
+		_ = reader.Close()
+	}
+	if !errors.Is(err, ErrJobLogUnavailable) {
+		t.Fatalf("unauthorized waiter error = %v, want %v", err, ErrJobLogUnavailable)
+	}
+	if err := <-leaderErr; err != nil {
+		t.Fatalf("authorized leader error = %v", err)
+	}
+}
+
 func TestClient_ConcurrentTTLExpiry_RefreshOnce(t *testing.T) {
 	mock := &mockBuildkiteAPI{
 		logContent: "\x1b_bk;t=1745322209921\x07running log entry\n",
@@ -405,8 +448,8 @@ func TestClient_ConcurrentTTLExpiry_RefreshOnce(t *testing.T) {
 	if statusCalls != 2 {
 		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
 	}
-	if existsCalls := mock.existsCalls(); existsCalls != 8 {
-		t.Fatalf("JobLogExists calls = %d, want 8", existsCalls)
+	if existsCalls := mock.existsCalls(); existsCalls != 9 {
+		t.Fatalf("JobLogExists calls = %d, want 9", existsCalls)
 	}
 }
 
@@ -436,8 +479,8 @@ func TestClient_NonTerminalCacheHit_ChecksJobLogAccess(t *testing.T) {
 	if statusCalls != 2 {
 		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
 	}
-	if existsCalls := mock.existsCalls(); existsCalls != 1 {
-		t.Fatalf("JobLogExists calls = %d, want 1", existsCalls)
+	if existsCalls := mock.existsCalls(); existsCalls != 2 {
+		t.Fatalf("JobLogExists calls = %d, want 2", existsCalls)
 	}
 }
 
@@ -517,6 +560,43 @@ func TestClient_ConcurrentForceRefresh_Coalesces(t *testing.T) {
 	}
 	if statusCalls != 2 {
 		t.Fatalf("GetJobStatus calls = %d, want 2", statusCalls)
+	}
+}
+
+func TestClient_ConcurrentForceRefresh_ValidatesWaiterIdentity(t *testing.T) {
+	mock := newTerminalMock()
+	api := &requestScopedBuildkiteAPI{mockBuildkiteAPI: mock}
+	client := newTestClient(t, api)
+	authorizedCtx := context.WithValue(t.Context(), requestIdentityKey{}, "authorized")
+	unauthorizedCtx := context.WithValue(t.Context(), requestIdentityKey{}, "unauthorized")
+
+	reader, err := client.NewReader(authorizedCtx, "org", "pipeline", "123", "job-1", time.Minute, false)
+	if err != nil {
+		t.Fatalf("populate cache: %v", err)
+	}
+	reader.Close()
+
+	mock.logDelay = 50 * time.Millisecond
+	mock.logStarted = make(chan struct{}, 1)
+	leaderErr := make(chan error, 1)
+	go func() {
+		reader, err := client.NewReader(authorizedCtx, "org", "pipeline", "123", "job-1", time.Minute, true)
+		if reader != nil {
+			_ = reader.Close()
+		}
+		leaderErr <- err
+	}()
+
+	<-mock.logStarted
+	reader, err = client.NewReader(unauthorizedCtx, "org", "pipeline", "123", "job-1", time.Minute, true)
+	if reader != nil {
+		_ = reader.Close()
+	}
+	if !errors.Is(err, ErrJobLogUnavailable) {
+		t.Fatalf("unauthorized waiter error = %v, want %v", err, ErrJobLogUnavailable)
+	}
+	if err := <-leaderErr; err != nil {
+		t.Fatalf("authorized leader error = %v", err)
 	}
 }
 

--- a/examples/high-level-client/README.md
+++ b/examples/high-level-client/README.md
@@ -84,8 +84,8 @@ The example uses `file://~/.bklog` as the storage URL, but you can use other bac
 
 - **TTL**: Set to 5 minutes in the example - logs are re-fetched if older than this
 - **Force Refresh**: Set to `false` - change to `true` to always re-download
-- **Access Checks**: Every cached read calls `JobLogExists` using the current API identity and fails closed if the log is missing or inaccessible
-- **Terminal Jobs**: Finished jobs are cached without a TTL or status lookup, but access is still checked before each read
+- **Access Checks**: Every request calls `JobLogExists` using the current API identity before cache handling, including cold misses and force refreshes
+- **Terminal Jobs**: Finished jobs are cached without a TTL or status lookup, but access is still checked before each request
 - **Non-terminal Jobs**: Within the TTL, current job state is checked so terminal transitions trigger an immediate final refresh
 
 ## Key Functions
@@ -100,8 +100,9 @@ Creates a client using a custom `BuildkiteAPI` implementation. Custom APIs must
 implement `GetJobStatus`, `JobLogExists`, and `GetJobLog`. `JobLogExists` must
 perform an authenticated check using the current API identity without fetching
 the log body. Return `false, nil` for a missing log and an error when the check
-fails. The client returns `ErrJobLogUnavailable` rather than serving cached data
-when the method returns false.
+fails. The client invokes it before every request, including initial downloads
+and force refreshes, and returns `ErrJobLogUnavailable` before using or joining
+shared cache work when the method returns false.
 
 This is an intentional source-breaking interface change during `0.x`
 development. The official implementation depends on

--- a/examples/smart-cache/README.md
+++ b/examples/smart-cache/README.md
@@ -6,7 +6,7 @@ This example demonstrates smart caching features using the high-level `Client` A
 
 - **High-level Client API** for simplified caching operations
 - **30-second TTL** for non-terminal jobs with automatic refresh
-- **Permanent freshness caching** for terminal jobs, with an authenticated `JobLogExists` check before every cached read
+- **Authenticated access checks** with `JobLogExists` before every request, including cold misses and force refreshes
 - **Force refresh** capability bypassing cache
 - **Multiple storage backends** (file://, s3://, gs://)
 - **Environment-aware defaults** (~/.bklog desktop, /tmp/bklog container)
@@ -59,4 +59,4 @@ go run main.go \
 5. **Different TTL values** and their effects
 6. **Job status-aware caching** behavior
 
-The example shows how the high-level `Client` API caches terminal jobs permanently for freshness while still checking the current API identity before every cached read. Non-terminal jobs refresh based on TTL, with metadata stored in blob attributes. Each example creates separate clients with different storage URLs to demonstrate various caching scenarios.
+The example shows how the high-level `Client` API checks the current API identity before every request can use or join cache work. This includes initial downloads, cache hits, and force refreshes. Terminal jobs are cached permanently for freshness, while non-terminal jobs refresh based on TTL with metadata stored in blob attributes. Each example creates separate clients with different storage URLs to demonstrate various caching scenarios.

--- a/org_scoped_api_test.go
+++ b/org_scoped_api_test.go
@@ -103,6 +103,8 @@ func TestOrgScopedJobAPI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/log"):
+			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/log"):
 			_ = json.NewEncoder(w).Encode(buildkite.JobLog{Content: logContent})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/jobs/"):


### PR DESCRIPTION
This change also adds more tests for concurrent access.